### PR TITLE
feat(blog): Add third match update for Canadian Nationals Day 1

### DIFF
--- a/blog.json
+++ b/blog.json
@@ -24,5 +24,18 @@
       "title": "Match #2 (Day 1): CAMO vs Deimos (EX) - A Tight Draw!",
       "content": "Second update from the National Championship!\n\n*   **Match Result:** CAMO draws 2-2 against Deimos (EX)!\n    *   Deimos is an excellent American team, with players who are candidates for the U.S. National Team.\n    *   They will not participate in the playoff rounds (as they are non-Canadian).\n*   **Highlight:** A penalty shot against us was brilliantly defended by Joseph! Unfortunately, the goal was disallowed by the referees due to a defensive foul.\n\nWhat an intense game!"
     }
+  },
+  {
+    "id": "post-20250613143000",
+    "timestamp": "2025-06-13T18:30:00Z",
+    "image": null,
+    "fr": {
+      "title": "Match #3 (Jour 1) : Victoire Éclatante de CAMO contre GTA Raccoons!",
+      "content": "Troisième compte-rendu du Championnat National - Jour 1 !\n\n*   **Résultat du match :** CAMO remporte une victoire décisive de 10-0 contre les GTA Raccoons !\n    *   Excellente défense de notre part, bloquant de nombreuses tentatives de buts adverses.\n    *   Les GTA Raccoons sont une jeune équipe prometteuse de la région de Toronto. Une belle relève qui s'annonce compétitive !\n*   **Notes de match :**\n    *   Un avertissement a été donné à notre capitaine, Philippe.\n    *   Début de match un peu lent et moins réactif, mais l'équipe s'est bien reprise par la suite !\n\nBravo CAMO !"
+    },
+    "en": {
+      "title": "Match #3 (Day 1): CAMO's Resounding Victory Over GTA Raccoons!",
+      "content": "Third update from the National Championship - Day 1!\n\n*   **Match Result:** CAMO secures a decisive 10-0 victory against the GTA Raccoons!\n    *   Excellent defense on our part, blocking numerous goal attempts from the opposition.\n    *   The GTA Raccoons are a young and promising team from the Greater Toronto Area. A fine new generation that will be very competitive in a few years.\n*   **Match Notes:**\n    *   A warning was issued to our captain, Philippe.\n    *   We were a bit slow and less reactive at the start of the match, but the team improved as it progressed!\n\nGo CAMO!"
+    }
   }
 ]


### PR DESCRIPTION
This commit adds a new blog post to `blog.json` detailing the results and notes from the third CAMO match on Day 1 of the Canadian Underwater Hockey Nationals (June 13, 2025).

The new post covers the CAMO vs GTA Raccoons match (10-0 victory for CAMO) and includes:
- French and English titles and content.
- A timestamp of 2025-06-13T18:30:00Z (2:30 PM EDT).

This provides a more complete account of CAMO's performance on the first day of the tournament.