### PR TITLE
feat: Add history page with reveal.js slideshow

### DIFF
--- a/history.html
+++ b/history.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="fr">
+<head>
+    <meta charset="utf-g">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>History of CAMO Underwater Hockey</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.6.1/reset.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.6.1/reveal.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.6.1/theme/black.min.css" id="theme">
+    <!-- Add any custom styles here if needed -->
+    <style>
+        /* Basic styles for language switcher */
+        .language-switcher {
+            position: fixed;
+            top: 10px;
+            right: 10px;
+            z-index: 1000;
+        }
+        .language-switcher button {
+            margin-left: 5px;
+            padding: 5px 10px;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+    <div class="reveal">
+        <div class="slides">
+            <!-- Slides will be loaded here -->
+            <section data-markdown="docs/histoire_camo_hockey_subaquatique.fr.md"
+                     data-separator="^\n---\n"
+                     data-separator-vertical="^\n--\n"
+                     data-separator-notes="^Note:"
+                     data-charset="utf-8">
+            </section>
+        </div>
+    </div>
+
+    <div class="language-switcher">
+        <button id="lang-fr">FR</button>
+        <button id="lang-en">EN</button>
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.6.1/reveal.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.6.1/plugin/markdown/markdown.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.6.1/plugin/notes/notes.min.js"></script>
+    <script>
+        Reveal.initialize({
+            hash: true,
+            plugins: [ RevealMarkdown, RevealNotes ],
+            // Adjust slide numbers to be visible
+            slideNumber: 'c/t',
+            // Other reveal.js options if needed
+        });
+
+        // Basic language switching logic (placeholder)
+        document.getElementById('lang-fr').addEventListener('click', function() {
+            // For now, clicking FR will ensure the French content is shown (which it is by default)
+            // In the future, this would explicitly load/show French content if English was active
+            alert('Version française affichée.');
+            // Potentially: Reveal.getPlugin('markdown').load('docs/histoire_camo_hockey_subaquatique.fr.md');
+            // Reveal.sync(); // Refresh reveal
+        });
+
+        document.getElementById('lang-en').addEventListener('click', function() {
+            // Placeholder for English version
+            // In the future, this would load 'docs/histoire_camo_hockey_subaquatique.en.md'
+            alert('English version is not yet available. Please provide the translation for docs/histoire_camo_hockey_subaquatique.en.md');
+            // Example of how it might work:
+            // Reveal.getPlugin('markdown').load('docs/histoire_camo_hockey_subaquatique.en.md'); // Imaginary EN file
+            // Reveal.sync(); // Refresh reveal
+        });
+    </script>
+</body>
+</html>

--- a/history.html
+++ b/history.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="fr">
 <head>
-    <meta charset="utf-g">
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>History of CAMO Underwater Hockey</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.6.1/reset.min.css">
@@ -28,8 +28,8 @@
         <div class="slides">
             <!-- Slides will be loaded here -->
             <section data-markdown="docs/histoire_camo_hockey_subaquatique.fr.md"
-                     data-separator="^\n---\n"
-                     data-separator-vertical="^\n--\n"
+                     data-separator="\r?\n## "
+                     data-separator-vertical="^\n----UNUSED----\n"
                      data-separator-notes="^Note:"
                      data-charset="utf-8">
             </section>
@@ -57,7 +57,7 @@
         document.getElementById('lang-fr').addEventListener('click', function() {
             // For now, clicking FR will ensure the French content is shown (which it is by default)
             // In the future, this would explicitly load/show French content if English was active
-            alert('Version française affichée.');
+            console.log('Version française affichée.');
             // Potentially: Reveal.getPlugin('markdown').load('docs/histoire_camo_hockey_subaquatique.fr.md');
             // Reveal.sync(); // Refresh reveal
         });
@@ -65,7 +65,7 @@
         document.getElementById('lang-en').addEventListener('click', function() {
             // Placeholder for English version
             // In the future, this would load 'docs/histoire_camo_hockey_subaquatique.en.md'
-            alert('English version is not yet available. Please provide the translation for docs/histoire_camo_hockey_subaquatique.en.md');
+            console.log('English version is not yet available. Please provide the translation for docs/histoire_camo_hockey_subaquatique.en.md');
             // Example of how it might work:
             // Reveal.getPlugin('markdown').load('docs/histoire_camo_hockey_subaquatique.en.md'); // Imaginary EN file
             // Reveal.sync(); // Refresh reveal

--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
             <p class="mt-1 text-md md:text-lg italic">Plongez dans l'action avec le Hockey et le Rugby Subaquatique !</p>
             <div class="mt-4">
                 <a href="blog.html" class="text-xl hover:underline font-semibold">Notre Blog</a>
+                <a href="history.html" class="text-xl hover:underline font-semibold ml-4">Notre Histoire</a>
             </div>
         </header>
 
@@ -272,6 +273,7 @@
             <p class="mt-1 text-md md:text-lg italic">Dive into the action with Underwater Hockey and Underwater Rugby!</p>
             <div class="mt-4">
                 <a href="blog.html" class="text-xl hover:underline font-semibold">Our Blog</a>
+                <a href="history.html" class="text-xl hover:underline font-semibold ml-4">Our History</a>
             </div>
         </header>
 


### PR DESCRIPTION
Creates a new `history.html` page that displays the content of `docs/histoire_camo_hockey_subaquatique.fr.md` as a slideshow presentation using `reveal.js`.

Key changes:
- Added `history.html` with `reveal.js` integration (via CDN) and markdown plugin to load and render the French history document.
- Implemented a basic language switcher on `history.html` with FR/EN buttons. Currently, only French content is available; the EN button displays a placeholder message.
- Added links to the new `history.html` page in the header of `index.html` for both French and English versions ("Notre Histoire" / "Our History").
- Ensured the `html` lang attribute is set to `fr` on `history.html`.

The slideshow is configured to separate slides based on markdown separators. Future work may include adding an English version of the history document and enhancing the language switching functionality.