### PR TITLE
feat: Enhance club history page with translation and styling

### DIFF
--- a/docs/histoire_camo_hockey_subaquatique.en.md
+++ b/docs/histoire_camo_hockey_subaquatique.en.md
@@ -14,7 +14,10 @@ We cannot discuss the history of the CAMO underwater hockey club without recount
 
 The interest in playing hockey owes much to its physical nature, allowing diving and spearfishing enthusiasts to stay in shape. As early as 1954, enthusiasm for the sport quickly led to the organization of inter-club matches, competitions, championships, media coverage, and even tourism promotions. Hockey then expanded throughout the Commonwealth.
 
-In 1960, six years later, under the influence of Bill Neil, the sport was reinvented in the United States in the Chicago area. Neil's style was very different from the English style. It was characterized by the use of a mini ice hockey stick held with two hands, and sometimes even a diving tank was worn. But the English style would eventually prevail in the United States, especially in the 1970s, under Canadian influence. This period saw hesitation between the two styles. The successive World Championships (1980 - Vancouver, 1982 - Brisbane) gradually convinced players to switch to the short stick. 1984 definitively enshrined this practice with the publication of the official C.M.A.S. rules following the Chicago World Championships.
+In 1960, six years later, under the influence of Bill Neil, the sport was reinvented in the United States in the Chicago area. Neil's style was very different from the English style. It was characterized by the use of a mini ice hockey stick held with two hands, and sometimes even a diving tank was worn. But the English style would eventually prevail in the United States, especially in the 1970s, under Canadian influence.
+
+## US Style and Standardization
+This period saw hesitation between the two styles. The successive World Championships (1980 - Vancouver, 1982 - Brisbane) gradually convinced players to switch to the short stick. 1984 definitively enshrined this practice with the publication of the official C.M.A.S. rules following the Chicago World Championships.
 
 In Canada, the history of underwater hockey began in 1962 in Vancouver with Australian diving instructor Norm Liebeck. It was from this origin that hockey gradually migrated eastward across the country.
 
@@ -22,12 +25,19 @@ In Canada, the history of underwater hockey began in 1962 in Vancouver with Aust
 
 In Quebec, hockey was introduced in 1965 under the influence of Rodrigue Sarrazin and Georges Bélanger. In the early 1970s, underwater hockey was documented at Maisonneuve College in Montreal as an extracurricular activity with Jean-Claude Rouisse. From there, a period of growth for the sport began in Quebec and elsewhere: the birth of clubs, the formalization of provincial (1976, St-Hyacinthe), national (1975, Winnipeg), and international (1980, Vancouver) competitions.
 
+## Early Clubs and Competitions in Quebec
 The precursors to CAMO were the JoncNoir from Maisonneuve College, the Evil Sharks from the Rosemont pool, and some players from Montérégie. Under the direction of Jean Couture, the Rosemont club officially adopted the name CAMO in 1978, following the Montreal Olympics. The acronym CAMO stands for Club Aquatique Montréal Olympique, which originated in 1964 with swimming and later with water polo.
 
+## National Success and First International Competitions
 Largely represented by CAMO club members, the 1982 Canadian Championship in Winnipeg marked the beginning of Quebec's success in the country, which until then had been dominated by Western Canada. Around the same time, the club turned its attention to the challenge of international competitions. In October 1983, a group of CAMO players undertook a trip to England. This overseas stay gave them the opportunity to compete against the best European teams. Their performance encouraged them to participate in the 1984 World Championship in Chicago, where they placed 5th, and the women's team placed 4th.
 
-Even at that time, there was a noticeable progression in the technical level of the teams. This development was largely due to the organization of World Championships since 1980, but also to a generation of exceptional players "produced" by CAMO. The contribution of Quebecers to the rise of modern underwater hockey is immense. The early signs of this "revolution" in individual technique were perceptible as early as 1984. Before each match, players practiced their technique at the edge of the pool. Two years later, these same players were crowned world champions at the expense of the Australians. In 1986, Quebecers were not known for their tactics or physical strength, but for their incredible individual technique. The 1986 victory, and Daniel Tétreault's year-long stay in Australia, convinced the Australians, as well as other nations, to further develop individual technique. 1988 and 1990 were also successful years, with the team finishing 3rd in the world consecutively.
+## Quebec's Technical Revolution
+Even at that time, there was a noticeable progression in the technical level of the teams. This development was largely due to the organization of World Championships since 1980, but also to a generation of exceptional players "produced" by CAMO. The contribution of Quebecers to the rise of modern underwater hockey is immense.
 
+## Global Recognition and Influence
+The early signs of this "revolution" in individual technique were perceptible as early as 1984. Before each match, players practiced their technique at the edge of the pool. Two years later, these same players were crowned world champions at the expense of the Australians. In 1986, Quebecers were not known for their tactics or physical strength, but for their incredible individual technique. The 1986 victory, and Daniel Tétreault's year-long stay in Australia, convinced the Australians, as well as other nations, to further develop individual technique. 1988 and 1990 were also successful years, with the team finishing 3rd in the world consecutively.
+
+## Club Transition and New Identity
 With the Lebeau brothers, the Pilon brothers, and their loyal friends, this international epic marked the era of an entire generation of exceptional athletes. After 1990, part of this generation gradually drifted away from the club, leaving room for a young succession that struggled to find its place. This was a period when the club was searching for a new identity, but above all, a permanent place to practice its passion. Its somewhat weakened organization consolidated in 1992 when the club moved to the Joseph-Charbonneau pool. The club progressed through a confluence of players from different clubs, which did not prevent it from maintaining its reputation and continuing to perform well in competitions.
 
 ## John F. Kennedy Aquatic Club
@@ -36,10 +46,16 @@ It took nearly 10 years to see the arrival of a new generation of athletes, main
 
 ## The 2010s
 
-The CAMO underwater hockey club experienced a revival in the 2010s. Recent years have seen the arrival of a new group of administrators pushing for sustainable development. In 2011, the club welcomed underwater rugby into its fold. In 2012, succeeding the late JFK Aquatic Club, CAMO took over the organization of the Montreal tournament at the Claude-Robillard Sports Complex, annually attracting, since the late 90s, about fifteen teams from Quebec, Ontario, Western Canada, and the United States.
+The CAMO underwater hockey club experienced a revival in the 2010s. Recent years have seen the arrival of a new group of administrators pushing for sustainable development. In 2011, the club welcomed underwater rugby into its fold.
+
+## Expansion and Tournament Organization
+In 2012, succeeding the late JFK Aquatic Club, CAMO took over the organization of the Montreal tournament at the Claude-Robillard Sports Complex, annually attracting, since the late 90s, about fifteen teams from Quebec, Ontario, Western Canada, and the United States.
 
 ## The CAMO Club Today
 
-At the club, one can find players from the older generation as well as elite Canadian players who have marked the history of hockey in Quebec, Canada, and around the world. The club proudly welcomes players of all levels, from here and elsewhere. As in the past, rookies and veterans train together to improve their game and gain experience. The level of play is intense, fast, and competitive.
+At the club, one can find players from the older generation as well as elite Canadian players who have marked the history of hockey in Quebec, Canada, and around the world. The club proudly welcomes players of all levels, from here and elsewhere.
+
+## Training and Competitiveness
+As in the past, rookies and veterans train together to improve their game and gain experience. The level of play is intense, fast, and competitive.
 
 Renowned for their competitive spirit, CAMO club members pass on their passion for hockey from generation to generation. The club has a very long tradition of winning. As its history attests, CAMO has a bright future and remains one of the most renowned underwater hockey clubs in North America.

--- a/docs/histoire_camo_hockey_subaquatique.en.md
+++ b/docs/histoire_camo_hockey_subaquatique.en.md
@@ -8,54 +8,76 @@ Sources:
 * François Rouisse
 * Lionel Dumaux
 
-## The Emergence of Underwater Hockey
+## The Emergence of Underwater Hockey (1954)
 
 We cannot discuss the history of the CAMO underwater hockey club without recounting the key moments in the emergence of the sport. Invented in 1954 in the south of England by Alan Blake, underwater hockey is associated with the image of the octopus's eight tentacles, representing a team of six players and two substitutes. The game, very rudimentary, simply consisted of pushing a brass puck with a small wooden stick. Thus, *Octopush* made its debut in sports history.
 
+## Initial Expansion (From 1954)
 The interest in playing hockey owes much to its physical nature, allowing diving and spearfishing enthusiasts to stay in shape. As early as 1954, enthusiasm for the sport quickly led to the organization of inter-club matches, competitions, championships, media coverage, and even tourism promotions. Hockey then expanded throughout the Commonwealth.
 
+## American Influence and Neil's Style (1960s)
 In 1960, six years later, under the influence of Bill Neil, the sport was reinvented in the United States in the Chicago area. Neil's style was very different from the English style. It was characterized by the use of a mini ice hockey stick held with two hands, and sometimes even a diving tank was worn. But the English style would eventually prevail in the United States, especially in the 1970s, under Canadian influence.
 
-## US Style and Standardization
+## Standardization and World Championships (1980-1984)
 This period saw hesitation between the two styles. The successive World Championships (1980 - Vancouver, 1982 - Brisbane) gradually convinced players to switch to the short stick. 1984 definitively enshrined this practice with the publication of the official C.M.A.S. rules following the Chicago World Championships.
 
+## Arrival in Canada (1962)
 In Canada, the history of underwater hockey began in 1962 in Vancouver with Australian diving instructor Norm Liebeck. It was from this origin that hockey gradually migrated eastward across the country.
 
-## CAMO, a Story of Passion
+## Introduction in Quebec (1965 - Early 1970s)
+In Quebec, hockey was introduced in 1965 under the influence of Rodrigue Sarrazin and Georges Bélanger. In the early 1970s, underwater hockey was documented at Maisonneuve College in Montreal as an extracurricular activity with Jean-Claude Rouisse.
 
-In Quebec, hockey was introduced in 1965 under the influence of Rodrigue Sarrazin and Georges Bélanger. In the early 1970s, underwater hockey was documented at Maisonneuve College in Montreal as an extracurricular activity with Jean-Claude Rouisse. From there, a period of growth for the sport began in Quebec and elsewhere: the birth of clubs, the formalization of provincial (1976, St-Hyacinthe), national (1975, Winnipeg), and international (1980, Vancouver) competitions.
+## Growth of the Sport in Quebec (1970s-1980s)
+From there, a period of growth for the sport began in Quebec and elsewhere: the birth of clubs, the formalization of provincial (1976, St-Hyacinthe), national (1975, Winnipeg), and international (1980, Vancouver) competitions.
 
-## Early Clubs and Competitions in Quebec
-The precursors to CAMO were the JoncNoir from Maisonneuve College, the Evil Sharks from the Rosemont pool, and some players from Montérégie. Under the direction of Jean Couture, the Rosemont club officially adopted the name CAMO in 1978, following the Montreal Olympics. The acronym CAMO stands for Club Aquatique Montréal Olympique, which originated in 1964 with swimming and later with water polo.
+## CAMO's Precursors (1970s)
+The precursors to CAMO were the JoncNoir from Maisonneuve College, the Evil Sharks from the Rosemont pool, and some players from Montérégie.
 
-## National Success and First International Competitions
+## Official Birth of CAMO (1978)
+Under the direction of Jean Couture, the Rosemont club officially adopted the name CAMO in 1978, following the Montreal Olympics. The acronym CAMO stands for Club Aquatique Montréal Olympique, which originated in 1964 with swimming and later with water polo.
+
+## National Success and Early International Competitions (1982-1984)
 Largely represented by CAMO club members, the 1982 Canadian Championship in Winnipeg marked the beginning of Quebec's success in the country, which until then had been dominated by Western Canada. Around the same time, the club turned its attention to the challenge of international competitions. In October 1983, a group of CAMO players undertook a trip to England. This overseas stay gave them the opportunity to compete against the best European teams. Their performance encouraged them to participate in the 1984 World Championship in Chicago, where they placed 5th, and the women's team placed 4th.
 
-## Quebec's Technical Revolution
+## Quebec's Technical Revolution (1980s)
 Even at that time, there was a noticeable progression in the technical level of the teams. This development was largely due to the organization of World Championships since 1980, but also to a generation of exceptional players "produced" by CAMO. The contribution of Quebecers to the rise of modern underwater hockey is immense.
 
-## Global Recognition and Influence
-The early signs of this "revolution" in individual technique were perceptible as early as 1984. Before each match, players practiced their technique at the edge of the pool. Two years later, these same players were crowned world champions at the expense of the Australians. In 1986, Quebecers were not known for their tactics or physical strength, but for their incredible individual technique. The 1986 victory, and Daniel Tétreault's year-long stay in Australia, convinced the Australians, as well as other nations, to further develop individual technique. 1988 and 1990 were also successful years, with the team finishing 3rd in the world consecutively.
+## Early Signs of the Technical Revolution (1984)
+The early signs of this "revolution" in individual technique were perceptible as early as 1984. Before each match, players practiced their technique at the edge of the pool.
 
-## Club Transition and New Identity
-With the Lebeau brothers, the Pilon brothers, and their loyal friends, this international epic marked the era of an entire generation of exceptional athletes. After 1990, part of this generation gradually drifted away from the club, leaving room for a young succession that struggled to find its place. This was a period when the club was searching for a new identity, but above all, a permanent place to practice its passion. Its somewhat weakened organization consolidated in 1992 when the club moved to the Joseph-Charbonneau pool. The club progressed through a confluence of players from different clubs, which did not prevent it from maintaining its reputation and continuing to perform well in competitions.
+## World Champions and Recognition (1986)
+Two years later, these same players were crowned world champions at the expense of the Australians. In 1986, Quebecers were not known for their tactics or physical strength, but for their incredible individual technique.
 
-## John F. Kennedy Aquatic Club
+## Influence on International Development (1986-1990)
+The 1986 victory, and Daniel Tétreault's year-long stay in Australia, convinced the Australians, as well as other nations, to further develop individual technique. 1988 and 1990 were also successful years, with the team finishing 3rd in the world consecutively.
 
-It took nearly 10 years to see the arrival of a new generation of athletes, mainly from the John F. Kennedy Aquatic Club. 1998 marked the return of CAMO players to the Canadian national team, and in 2000, some of them experienced the joy of the podium, winning bronze and silver medals.
+## Generation of Exceptional Athletes (Late 1980s)
+With the Lebeau brothers, the Pilon brothers, and their loyal friends, this international epic marked the era of an entire generation of exceptional athletes.
 
-## The 2010s
+## Post-1990 Transition Period (Early 1990s)
+After 1990, part of this generation gradually drifted away from the club, leaving room for a young succession that struggled to find its place. This was a period when the club was searching for a new identity, but above all, a permanent place to practice its passion.
 
+## Consolidation at Joseph-Charbonneau (1992)
+Its somewhat weakened organization consolidated in 1992 when the club moved to the Joseph-Charbonneau pool. The club progressed through a confluence of players from different clubs, which did not prevent it from maintaining its reputation and continuing to perform well in competitions.
+
+## Next Generation from John F. Kennedy Aquatic Club (1998-2000)
+It took nearly 10 years to see the arrival of a new generation of
+athletes, mainly from the John F. Kennedy Aquatic Club. 1998 marked
+the return of CAMO players to the Canadian national team, and in 2000,
+some of them experienced the joy of the podium, winning bronze and
+silver medals.
+
+## Revival and Sustainable Development (2010-2011)
 The CAMO underwater hockey club experienced a revival in the 2010s. Recent years have seen the arrival of a new group of administrators pushing for sustainable development. In 2011, the club welcomed underwater rugby into its fold.
 
-## Expansion and Tournament Organization
+## Organization of the Montreal Tournament (Since 2012)
 In 2012, succeeding the late JFK Aquatic Club, CAMO took over the organization of the Montreal tournament at the Claude-Robillard Sports Complex, annually attracting, since the late 90s, about fifteen teams from Quebec, Ontario, Western Canada, and the United States.
 
-## The CAMO Club Today
-
+## The CAMO Club Today (Present)
 At the club, one can find players from the older generation as well as elite Canadian players who have marked the history of hockey in Quebec, Canada, and around the world. The club proudly welcomes players of all levels, from here and elsewhere.
 
-## Training and Competitiveness
+## Training and Level of Play (Present)
 As in the past, rookies and veterans train together to improve their game and gain experience. The level of play is intense, fast, and competitive.
 
+## Legacy and Future (Present)
 Renowned for their competitive spirit, CAMO club members pass on their passion for hockey from generation to generation. The club has a very long tradition of winning. As its history attests, CAMO has a bright future and remains one of the most renowned underwater hockey clubs in North America.

--- a/docs/histoire_camo_hockey_subaquatique.fr.md
+++ b/docs/histoire_camo_hockey_subaquatique.fr.md
@@ -14,7 +14,10 @@ On ne peut aborder l’histoire du club CAMO hockey sous-marin sans retracer les
 
 L’intérêt pour la pratique du hockey doit beaucoup au caractère physique permettant aux amateurs de plongée et de chasse sous-marine de garder la forme. Dès 1954, l’enthousiasme pour la discipline se traduit rapidement par l’organisation de joutes entre clubs, de compétitions, de championnats, de parutions médiatiques, même de promotions à travers le tourisme. Le hockey connait alors une expansion dans le Commonwealth.
 
-En 1960, six ans plus tard, sous l’influence de Bill Neil, la discipline se réinvente aux États-Unis dans la région de Chicago. Le style de Neil est fort différent du style anglais. Il se démarque par l’utilisation d’un mini bâton de hockey sur glace tenu à deux mains et, parfois, on porte même la bouteille de plongée. Mais le style anglais s’imposera aux États-Unis surtout dans les années 70 sous l’influence du Canada. On assiste alors à une période d’hésitation entre les deux styles. C’est la tenue successive de Championnats du monde (1980 \- Vancouver, 1982 \- Brisbane) qui progressivement convint les adeptes de passer au bâton court. 1984 consacre définitivement cet usage avec la publication du règlement officiel de la C.M.A.S dans la foulée du Championnats du monde de Chicago. 
+En 1960, six ans plus tard, sous l’influence de Bill Neil, la discipline se réinvente aux États-Unis dans la région de Chicago. Le style de Neil est fort différent du style anglais. Il se démarque par l’utilisation d’un mini bâton de hockey sur glace tenu à deux mains et, parfois, on porte même la bouteille de plongée. Mais le style anglais s’imposera aux États-Unis surtout dans les années 70 sous l’influence du Canada.
+
+## Influence américaine et normalisation
+On assiste alors à une période d’hésitation entre les deux styles. C’est la tenue successive de Championnats du monde (1980 \- Vancouver, 1982 \- Brisbane) qui progressivement convint les adeptes de passer au bâton court. 1984 consacre définitivement cet usage avec la publication du règlement officiel de la C.M.A.S dans la foulée du Championnats du monde de Chicago.
 
 Au Canada, l’histoire du hockey subaquatique débute en 1962 à Vancouver avec l’instructeur de plongée australien Norm Liebeck. C’est d’ailleurs à partir de cette souche que le hockey migre progressivement vers l’est du pays.
 
@@ -22,11 +25,19 @@ Au Canada, l’histoire du hockey subaquatique débute en 1962 à Vancouver avec
 
 Au Québec, le hockey s’implante en 1965 sous l’influence de Rodrigue Sarrazin et de Georges Bélanger. Au début des années 70, on recense du hockey subaquatique au collège de Maisonneuve de Montréal sous la forme d’une activité parascolaire avec Jean-Claude Rouisse. De là s’amorce une période de croissance de la discipline au Québec et ailleurs: naissance de clubs, officialisation de compétitions provinciales (1976, St-Hyacinthe), nationales (1975, Winnipeg) et internationales (1980, Vancouver). 
 
+## Premiers clubs et compétitions au Québec
 Les précurseurs de CAMO sont les JoncNoir du collège de Maisonneuve, les Evil Shark de la piscine de Rosemont et quelques joueurs de la Montérégie. Sous la direction de Jean Couture, le club de Rosemont adopte officiellement en 1978 le nom de CAMO dans la foulée des jeux Olympiques de Montréal. L’acronyme CAMO signifie d’ailleurs Club Aquatique Montréal Olympique qui prend racines en 1964 avec la natation et plus tard avec le water-polo.  
+
+## Succès nationaux et premières compétitions internationales
 Largement représenté par les membres du club CAMO, le championnat canadien de Winnipeg en 1982 marque le début du succès du Québec au pays, jusque-là dominé par l’Ouest canadien. À cette même époque, le club se tourne vers le défi des compétitions internationales. En octobre 1983, un groupe de joueurs de CAMO entreprennent un voyage en Angleterre. Ce séjour outre-mer leur donne l'occasion de se mesurer aux meilleures équipes européennes. Leur performance les encourage à participer au Championnat du monde de Chicago en 1984 où ils se classeront au 5e rang et au 4e rang chez les filles.
 
-On note déjà à cette époque une progression du niveau technique des équipes. Ce développement est notamment dû à l'organisation de Championnats du monde depuis 1980, mais aussi à une génération de joueurs d'exception "produits" par CAMO. L’apport des Québécois est immense à l'éclosion du hockey subaquatique moderne. Les prémices de cette "révolution" dans le domaine de la technique individuelle étaient perceptibles dès 1984\. Avant chaque match, les joueurs exerçaient leur technique au bord du bassin. Deux ans plus tard, ces mêmes joueurs étaient sacrés champions du monde aux dépens des Australiens. En 1986, les Québécois n’étaient pas reconnus pour leur tactique ni leur puissance physique, mais pour leur incroyable technique individuelle. La victoire de 1986, et le séjour d’un an de Daniel Tétreault en Australie ont d'ailleurs convaincu les Australiens, tout comme les autres nations, de développer encore plus la technique individuelle. 1988 et 1990 seront aussi couronnées de succès en occupant successivement le 3e rang mondial.
+## Révolution technique québécoise
+On note déjà à cette époque une progression du niveau technique des équipes. Ce développement est notamment dû à l'organisation de Championnats du monde depuis 1980, mais aussi à une génération de joueurs d'exception "produits" par CAMO. L’apport des Québécois est immense à l'éclosion du hockey subaquatique moderne.
 
+## Reconnaissance mondiale et influence
+Les prémices de cette "révolution" dans le domaine de la technique individuelle étaient perceptibles dès 1984\. Avant chaque match, les joueurs exerçaient leur technique au bord du bassin. Deux ans plus tard, ces mêmes joueurs étaient sacrés champions du monde aux dépens des Australiens. En 1986, les Québécois n’étaient pas reconnus pour leur tactique ni leur puissance physique, mais pour leur incroyable technique individuelle. La victoire de 1986, et le séjour d’un an de Daniel Tétreault en Australie ont d'ailleurs convaincu les Australiens, tout comme les autres nations, de développer encore plus la technique individuelle. 1988 et 1990 seront aussi couronnées de succès en occupant successivement le 3e rang mondial.
+
+## Transition et nouvelle identité du club
 Avec les frères Lebeau, les frères Pilon, et leurs fidèles amis, cette épopée internationale marque la période de toute une génération d’athlètes d’exception. Après 1990, une partie de cette génération s’éloigne peu à peu du club, laissant place à une jeune relève qui peine à prendre sa place. C’est une période où le club se cherche une nouvelle identité, mais surtout un lieu fixe pour exercer sa passion. Son organisation quelque peu affaiblie se consolide en 1992 lorsque le club s’installe à la piscine Joseph-Charbonneau. Le club progresse par un confluent de joueurs issus de différents clubs, ce qui ne l’empêche pas de maintenir sa renommée et de continuer à faire bonne figure en compétition. 
 
 ## Club Aquatique John F. Kennedy
@@ -35,11 +46,17 @@ Il faut attendre près de 10 ans avant de voir arriver une nouvelle génération
 
 ## Les années 2010
 
-Le club CAMO hockey sous-marin vit un renouveau dans les années 2010. Les dernières années ont vu arriver un nouveau groupe d'administrateurs qui poussent pour un développement durable. En 2011, le club accueille le rugby sous-marin dans son giron. En 2012, succédant au feu Club Aquatique de JFK, CAMO prend sous sa gouverne l’organisation du tournoi de Montréal au Complexe sportif Claude-Robillard attirant annuellement, depuis la fin des années 90, une quinzaine d’équipes du Québec, de l’Ontario, de l’ouest du pays et des États-Unis.  
+Le club CAMO hockey sous-marin vit un renouveau dans les années 2010. Les dernières années ont vu arriver un nouveau groupe d'administrateurs qui poussent pour un développement durable. En 2011, le club accueille le rugby sous-marin dans son giron.
+
+## Expansion et organisation de tournois
+En 2012, succédant au feu Club Aquatique de JFK, CAMO prend sous sa gouverne l’organisation du tournoi de Montréal au Complexe sportif Claude-Robillard attirant annuellement, depuis la fin des années 90, une quinzaine d’équipes du Québec, de l’Ontario, de l’ouest du pays et des États-Unis.
 
 ## Le club CAMO aujourd'hui
 
-Au club, on y rencontre autant des joueurs de l’ancienne génération que des joueurs de l’élite canadienne qui ont marqué l’histoire du hockey au Québec, au Canada et dans le monde. Le club accueille avec fierté les joueurs de tous niveaux d’ici et d’ailleurs. Comme par le passé, recrues et anciens s’y entraînent pour améliorer leur niveau de jeu et gagner en expérience. Le niveau de jeu est intense, rapide et compétitif. 
+Au club, on y rencontre autant des joueurs de l’ancienne génération que des joueurs de l’élite canadienne qui ont marqué l’histoire du hockey au Québec, au Canada et dans le monde. Le club accueille avec fierté les joueurs de tous niveaux d’ici et d’ailleurs.
+
+## Entraînement et compétitivité
+Comme par le passé, recrues et anciens s’y entraînent pour améliorer leur niveau de jeu et gagner en expérience. Le niveau de jeu est intense, rapide et compétitif.
 
 Réputés pour leur goût de la compétition, les membres du club CAMO se transmettent la passion du hockey de génération en génération. Le club a une très longue tradition de gagnant. Comme en témoigne son histoire, CAMO a un brillant avenir et demeure l'un des clubs de hockey subaquatique les plus renommés en Amérique du Nord.
 

--- a/docs/histoire_camo_hockey_subaquatique.fr.md
+++ b/docs/histoire_camo_hockey_subaquatique.fr.md
@@ -8,56 +8,74 @@ Sources :
 * François Rouisse  
 * Lionel Dumaux
 
-## L’émergence du hockey subaquatique
+## L’émergence du hockey subaquatique (1954)
 
 On ne peut aborder l’histoire du club CAMO hockey sous-marin sans retracer les moments forts de l’émergence de la discipline. Inventé en 1954 dans le sud de l’Angleterre par Alan Blake, le hockey subaquatique est associé à l’image des huit tentacules de la pieuvre représentant une équipe composée de six joueurs et de deux remplaçants. Le jeu, très rudimentaire, consistait simplement à pousser une rondelle de laiton à l’aide d’une petite fourche en bois. Ainsi, l’*Octopush* faisait son entrée dans l’histoire du sport.
 
+## Expansion initiale (Dès 1954)
 L’intérêt pour la pratique du hockey doit beaucoup au caractère physique permettant aux amateurs de plongée et de chasse sous-marine de garder la forme. Dès 1954, l’enthousiasme pour la discipline se traduit rapidement par l’organisation de joutes entre clubs, de compétitions, de championnats, de parutions médiatiques, même de promotions à travers le tourisme. Le hockey connait alors une expansion dans le Commonwealth.
 
+## Influence américaine et style Neil (1960s)
 En 1960, six ans plus tard, sous l’influence de Bill Neil, la discipline se réinvente aux États-Unis dans la région de Chicago. Le style de Neil est fort différent du style anglais. Il se démarque par l’utilisation d’un mini bâton de hockey sur glace tenu à deux mains et, parfois, on porte même la bouteille de plongée. Mais le style anglais s’imposera aux États-Unis surtout dans les années 70 sous l’influence du Canada.
 
-## Influence américaine et normalisation
+## Standardisation et Championnats du Monde (1980-1984)
 On assiste alors à une période d’hésitation entre les deux styles. C’est la tenue successive de Championnats du monde (1980 \- Vancouver, 1982 \- Brisbane) qui progressivement convint les adeptes de passer au bâton court. 1984 consacre définitivement cet usage avec la publication du règlement officiel de la C.M.A.S dans la foulée du Championnats du monde de Chicago.
 
+## Arrivée au Canada (1962)
 Au Canada, l’histoire du hockey subaquatique débute en 1962 à Vancouver avec l’instructeur de plongée australien Norm Liebeck. C’est d’ailleurs à partir de cette souche que le hockey migre progressivement vers l’est du pays.
 
-## CAMO, une histoire de passion
+## Implantation au Québec (1965 - Début Années 70)
+Au Québec, le hockey s’implante en 1965 sous l’influence de Rodrigue Sarrazin et de Georges Bélanger. Au début des années 70, on recense du hockey subaquatique au collège de Maisonneuve de Montréal sous la forme d’une activité parascolaire avec Jean-Claude Rouisse.
 
-Au Québec, le hockey s’implante en 1965 sous l’influence de Rodrigue Sarrazin et de Georges Bélanger. Au début des années 70, on recense du hockey subaquatique au collège de Maisonneuve de Montréal sous la forme d’une activité parascolaire avec Jean-Claude Rouisse. De là s’amorce une période de croissance de la discipline au Québec et ailleurs: naissance de clubs, officialisation de compétitions provinciales (1976, St-Hyacinthe), nationales (1975, Winnipeg) et internationales (1980, Vancouver). 
+## Croissance de la discipline au Québec (Années 70-80)
+De là s’amorce une période de croissance de la discipline au Québec et ailleurs: naissance de clubs, officialisation de compétitions provinciales (1976, St-Hyacinthe), nationales (1975, Winnipeg) et internationales (1980, Vancouver).
 
-## Premiers clubs et compétitions au Québec
-Les précurseurs de CAMO sont les JoncNoir du collège de Maisonneuve, les Evil Shark de la piscine de Rosemont et quelques joueurs de la Montérégie. Sous la direction de Jean Couture, le club de Rosemont adopte officiellement en 1978 le nom de CAMO dans la foulée des jeux Olympiques de Montréal. L’acronyme CAMO signifie d’ailleurs Club Aquatique Montréal Olympique qui prend racines en 1964 avec la natation et plus tard avec le water-polo.  
+## Les précurseurs de CAMO (Années 70)
+Les précurseurs de CAMO sont les JoncNoir du collège de Maisonneuve, les Evil Shark de la piscine de Rosemont et quelques joueurs de la Montérégie.
 
-## Succès nationaux et premières compétitions internationales
+## Naissance officielle de CAMO (1978)
+Sous la direction de Jean Couture, le club de Rosemont adopte officiellement en 1978 le nom de CAMO dans la foulée des jeux Olympiques de Montréal. L’acronyme CAMO signifie d’ailleurs Club Aquatique Montréal Olympique qui prend racines en 1964 avec la natation et plus tard avec le water-polo.
+
+## Succès nationaux et débuts internationaux (1982-1984)
 Largement représenté par les membres du club CAMO, le championnat canadien de Winnipeg en 1982 marque le début du succès du Québec au pays, jusque-là dominé par l’Ouest canadien. À cette même époque, le club se tourne vers le défi des compétitions internationales. En octobre 1983, un groupe de joueurs de CAMO entreprennent un voyage en Angleterre. Ce séjour outre-mer leur donne l'occasion de se mesurer aux meilleures équipes européennes. Leur performance les encourage à participer au Championnat du monde de Chicago en 1984 où ils se classeront au 5e rang et au 4e rang chez les filles.
 
-## Révolution technique québécoise
+## Révolution technique québécoise (Années 80)
 On note déjà à cette époque une progression du niveau technique des équipes. Ce développement est notamment dû à l'organisation de Championnats du monde depuis 1980, mais aussi à une génération de joueurs d'exception "produits" par CAMO. L’apport des Québécois est immense à l'éclosion du hockey subaquatique moderne.
 
-## Reconnaissance mondiale et influence
-Les prémices de cette "révolution" dans le domaine de la technique individuelle étaient perceptibles dès 1984\. Avant chaque match, les joueurs exerçaient leur technique au bord du bassin. Deux ans plus tard, ces mêmes joueurs étaient sacrés champions du monde aux dépens des Australiens. En 1986, les Québécois n’étaient pas reconnus pour leur tactique ni leur puissance physique, mais pour leur incroyable technique individuelle. La victoire de 1986, et le séjour d’un an de Daniel Tétreault en Australie ont d'ailleurs convaincu les Australiens, tout comme les autres nations, de développer encore plus la technique individuelle. 1988 et 1990 seront aussi couronnées de succès en occupant successivement le 3e rang mondial.
+## Prémices de la révolution technique (1984)
+Les prémices de cette "révolution" dans le domaine de la technique individuelle étaient perceptibles dès 1984\. Avant chaque match, les joueurs exerçaient leur technique au bord du bassin.
 
-## Transition et nouvelle identité du club
-Avec les frères Lebeau, les frères Pilon, et leurs fidèles amis, cette épopée internationale marque la période de toute une génération d’athlètes d’exception. Après 1990, une partie de cette génération s’éloigne peu à peu du club, laissant place à une jeune relève qui peine à prendre sa place. C’est une période où le club se cherche une nouvelle identité, mais surtout un lieu fixe pour exercer sa passion. Son organisation quelque peu affaiblie se consolide en 1992 lorsque le club s’installe à la piscine Joseph-Charbonneau. Le club progresse par un confluent de joueurs issus de différents clubs, ce qui ne l’empêche pas de maintenir sa renommée et de continuer à faire bonne figure en compétition. 
+## Champions du Monde et reconnaissance (1986)
+Deux ans plus tard, ces mêmes joueurs étaient sacrés champions du monde aux dépens des Australiens. En 1986, les Québécois n’étaient pas reconnus pour leur tactique ni leur puissance physique, mais pour leur incroyable technique individuelle.
 
-## Club Aquatique John F. Kennedy
+## Influence sur le développement international (1986-1990)
+La victoire de 1986, et le séjour d’un an de Daniel Tétreault en Australie ont d'ailleurs convaincu les Australiens, tout comme les autres nations, de développer encore plus la technique individuelle. 1988 et 1990 seront aussi couronnées de succès en occupant successivement le 3e rang mondial.
 
+## Génération d'athlètes d'exception (Fin Années 80)
+Avec les frères Lebeau, les frères Pilon, et leurs fidèles amis, cette épopée internationale marque la période de toute une génération d’athlètes d’exception.
+
+## Période de transition post-1990 (Début Années 90)
+Après 1990, une partie de cette génération s’éloigne peu à peu du club, laissant place à une jeune relève qui peine à prendre sa place. C’est une période où le club se cherche une nouvelle identité, mais surtout un lieu fixe pour exercer sa passion.
+
+## Consolidation à Joseph-Charbonneau (1992)
+Son organisation quelque peu affaiblie se consolide en 1992 lorsque le club s’installe à la piscine Joseph-Charbonneau. Le club progresse par un confluent de joueurs issus de différents clubs, ce qui ne l’empêche pas de maintenir sa renommée et de continuer à faire bonne figure en compétition.
+
+## Relève du Club Aquatique John F. Kennedy (1998-2000)
 Il faut attendre près de 10 ans avant de voir arriver une nouvelle génération d’athlètes issus principalement du Club Aquatique John F. Kennedy. 1998 marque le retour des joueurs de CAMO au sein de l’équipe nationale du Canada, et 2000 permet à certains d’entre eux de goûter aux joies de podium en remportant la médaille de bronze et la médaille d’argent.
 
-## Les années 2010
-
+## Renouveau et développement durable (2010-2011)
 Le club CAMO hockey sous-marin vit un renouveau dans les années 2010. Les dernières années ont vu arriver un nouveau groupe d'administrateurs qui poussent pour un développement durable. En 2011, le club accueille le rugby sous-marin dans son giron.
 
-## Expansion et organisation de tournois
+## Organisation du tournoi de Montréal (Depuis 2012)
 En 2012, succédant au feu Club Aquatique de JFK, CAMO prend sous sa gouverne l’organisation du tournoi de Montréal au Complexe sportif Claude-Robillard attirant annuellement, depuis la fin des années 90, une quinzaine d’équipes du Québec, de l’Ontario, de l’ouest du pays et des États-Unis.
 
-## Le club CAMO aujourd'hui
-
+## Le club CAMO aujourd'hui (Présent)
 Au club, on y rencontre autant des joueurs de l’ancienne génération que des joueurs de l’élite canadienne qui ont marqué l’histoire du hockey au Québec, au Canada et dans le monde. Le club accueille avec fierté les joueurs de tous niveaux d’ici et d’ailleurs.
 
-## Entraînement et compétitivité
+## Entraînement et niveau de jeu (Présent)
 Comme par le passé, recrues et anciens s’y entraînent pour améliorer leur niveau de jeu et gagner en expérience. Le niveau de jeu est intense, rapide et compétitif.
 
+## Héritage et avenir (Présent)
 Réputés pour leur goût de la compétition, les membres du club CAMO se transmettent la passion du hockey de génération en génération. Le club a une très longue tradition de gagnant. Comme en témoigne son histoire, CAMO a un brillant avenir et demeure l'un des clubs de hockey subaquatique les plus renommés en Amérique du Nord.
 
 

--- a/history.html
+++ b/history.html
@@ -52,6 +52,22 @@
         .reveal .slides section:nth-child(5n+6) h2 { /* This covers the 5th color in the cycle for slides 6, 11, 16... */
             color: #E6E6FA !important; /* Lavender */
         }
+
+        /* Define font sizes for clear visual hierarchy */
+        .reveal .slides section h1 {
+            font-size: 2.2em !important; /* Larger for main titles */
+            margin-bottom: 20px !important; /* Slightly more space for H1 */
+        }
+
+        .reveal .slides section h2 {
+            font-size: 1.6em !important; /* Medium for slide titles */
+            margin-bottom: 15px !important; /* Consistent with general heading rule but explicit here */
+        }
+
+        .reveal .slides section p {
+            font-size: 0.9em !important; /* Standard for body text */
+            line-height: 1.4em !important; /* Improve readability for paragraphs */
+        }
     </style>
 </head>
 <body>

--- a/history.html
+++ b/history.html
@@ -21,6 +21,37 @@
             padding: 5px 10px;
             cursor: pointer;
         }
+
+        .reveal .slides section h1,
+        .reveal .slides section h2 { /* Target h1 and h2 for color styling */
+            /* Add a common style if needed, or leave it to specific nth-child rules */
+        }
+
+        /* Style for the main title (first slide, usually h1) */
+        .reveal .slides section:first-child h1 {
+            color: #FFFFFF; /* White, or another prominent color for the main title */
+        }
+        .reveal .slides section:first-child h2 {
+            color: #FFFFFF; /* White, or another prominent color for the main title */
+        }
+
+
+        /* Cycle through 5 different colors for subsequent slide headings (h2) */
+        .reveal .slides section:not(:first-child):nth-of-type(5n+1) h2 { /* Start cycle after the first slide */
+            color: #FFB6C1; /* LightPink */
+        }
+        .reveal .slides section:not(:first-child):nth-of-type(5n+2) h2 {
+            color: #ADD8E6; /* LightBlue */
+        }
+        .reveal .slides section:not(:first-child):nth-of-type(5n+3) h2 {
+            color: #90EE90; /* LightGreen */
+        }
+        .reveal .slides section:not(:first-child):nth-of-type(5n+4) h2 {
+            color: #FFDAB9; /* PeachPuff */
+        }
+        .reveal .slides section:not(:first-child):nth-of-type(5n+5) h2 {
+            color: #E6E6FA; /* Lavender */
+        }
     </style>
 </head>
 <body>
@@ -53,22 +84,19 @@
             // Other reveal.js options if needed
         });
 
-        // Basic language switching logic (placeholder)
+        // Language switching logic
+        const markdownSection = document.querySelector('.slides section[data-markdown]');
+
         document.getElementById('lang-fr').addEventListener('click', function() {
-            // For now, clicking FR will ensure the French content is shown (which it is by default)
-            // In the future, this would explicitly load/show French content if English was active
-            console.log('Version française affichée.');
-            // Potentially: Reveal.getPlugin('markdown').load('docs/histoire_camo_hockey_subaquatique.fr.md');
-            // Reveal.sync(); // Refresh reveal
+            markdownSection.setAttribute('data-markdown', 'docs/histoire_camo_hockey_subaquatique.fr.md');
+            Reveal.getPlugin('markdown').load('docs/histoire_camo_hockey_subaquatique.fr.md');
+            Reveal.sync();
         });
 
         document.getElementById('lang-en').addEventListener('click', function() {
-            // Placeholder for English version
-            // In the future, this would load 'docs/histoire_camo_hockey_subaquatique.en.md'
-            console.log('English version is not yet available. Please provide the translation for docs/histoire_camo_hockey_subaquatique.en.md');
-            // Example of how it might work:
-            // Reveal.getPlugin('markdown').load('docs/histoire_camo_hockey_subaquatique.en.md'); // Imaginary EN file
-            // Reveal.sync(); // Refresh reveal
+            markdownSection.setAttribute('data-markdown', 'docs/histoire_camo_hockey_subaquatique.en.md');
+            Reveal.getPlugin('markdown').load('docs/histoire_camo_hockey_subaquatique.en.md');
+            Reveal.sync();
         });
     </script>
 </body>

--- a/history.html
+++ b/history.html
@@ -22,35 +22,35 @@
             cursor: pointer;
         }
 
+        /* Improve spacing for headings within slides */
         .reveal .slides section h1,
-        .reveal .slides section h2 { /* Target h1 and h2 for color styling */
-            /* Add a common style if needed, or leave it to specific nth-child rules */
+        .reveal .slides section h2,
+        .reveal .slides section h3,
+        .reveal .slides section h4,
+        .reveal .slides section h5,
+        .reveal .slides section h6 {
+            margin-bottom: 15px !important; /* Add space below all headings */
+        }
+
+        /* Ensure default theme's h1/h2 color is overridden if it's too strong */
+        .reveal .slides section h1,
+        .reveal .slides section h2 {
+            color: #DDDDDD; /* Default light color for headings if not specified otherwise */
         }
 
         /* Style for the main title (first slide, usually h1) */
-        .reveal .slides section:first-child h1 {
-            color: #FFFFFF; /* White, or another prominent color for the main title */
-        }
-        .reveal .slides section:first-child h2 {
-            color: #FFFFFF; /* White, or another prominent color for the main title */
+        .reveal .slides section:nth-child(1) h1,
+        .reveal .slides section:nth-child(1) h2 { /* If h2 on first slide */
+            color: #FFFFFF !important; /* White, added !important as a test */
         }
 
-
-        /* Cycle through 5 different colors for subsequent slide headings (h2) */
-        .reveal .slides section:not(:first-child):nth-of-type(5n+1) h2 { /* Start cycle after the first slide */
-            color: #FFB6C1; /* LightPink */
-        }
-        .reveal .slides section:not(:first-child):nth-of-type(5n+2) h2 {
-            color: #ADD8E6; /* LightBlue */
-        }
-        .reveal .slides section:not(:first-child):nth-of-type(5n+3) h2 {
-            color: #90EE90; /* LightGreen */
-        }
-        .reveal .slides section:not(:first-child):nth-of-type(5n+4) h2 {
-            color: #FFDAB9; /* PeachPuff */
-        }
-        .reveal .slides section:not(:first-child):nth-of-type(5n+5) h2 {
-            color: #E6E6FA; /* Lavender */
+        /* For subsequent slides */
+        .reveal .slides section:nth-child(5n+2) h2 { color: #FFB6C1 !important; /* LightPink - Slide 2, 7, 12... */ }
+        .reveal .slides section:nth-child(5n+3) h2 { color: #ADD8E6 !important; /* LightBlue - Slide 3, 8, 13... */ }
+        .reveal .slides section:nth-child(5n+4) h2 { color: #90EE90 !important; /* LightGreen - Slide 4, 9, 14... */ }
+        .reveal .slides section:nth-child(5n+5) h2 { color: #FFDAB9 !important; /* PeachPuff - Slide 5, 10, 15... */ }
+        .reveal .slides section:nth-child(5n+6) h2 { /* This covers the 5th color in the cycle for slides 6, 11, 16... */
+            color: #E6E6FA !important; /* Lavender */
         }
     </style>
 </head>


### PR DESCRIPTION
This commit introduces several improvements to history.html:

1.  **English Translation**: The English translation of the club history (`docs/histoire_camo_hockey_subaquatique.en.md`) is now integrated and accessible via a language switcher on `history.html`.

2.  **Content Restructuring**: Both the French and English Markdown history files (`...fr.md` and `...en.md`) have been updated with additional `##` headings. This breaks down longer texts into more numerous, shorter slides, as required by the Reveal.js slide format which displays one paragraph per slide effectively.

3.  **Language Switching**: The JavaScript in `history.html` has been updated to dynamically load the selected language's Markdown file (French or English) into the Reveal.js presentation when the corresponding language button is clicked.

4.  **Colorful Headings**: CSS styles have been added to `history.html` to provide visual differentiation for headings on slides. The main title slide's headings are styled distinctly, and subsequent slide headings cycle through a set of predefined colors.

These changes make the club history more accessible and engaging for both French and English-speaking users.