### PR TITLE
Add blog post for UWH Nationals 2025 Match #4

### DIFF
--- a/blog.json
+++ b/blog.json
@@ -61,11 +61,11 @@
       "tags": ["uwh_nationals_2025"],
       "fr": {
         "title": "Match #4 (Jour 1) : CAMO vs Raies de Rimouski",
-        "content": "Quatrième mise à jour du Championnat National - Jour 1 !\n\n*   **Résultat du match :** Victoire de CAMO 4-0 contre les Raies de Rimouski !\n*   **Notes de match :**\n    *   Jeu intense et quelques erreurs de notre part.\n    *   Un arrêt de jeu prolongé car notre joueur Richard a reçu la rondelle au visage.\n    *   Malgré l'heure tardive et la longue pause, ce fut un match agréable.\n\nEncore une victoire pour CAMO !"
+        "content": "Quatrième mise à jour du Championnat National - Jour 1 !\n\n*   **Résultat du match :** Victoire de CAMO 4-0 contre les Raies de Rimouski !\n*   **Notes de match :**\n    *   Jeu intense et quelques erreurs de notre part, avec plusieurs arrêts de jeu.\n    *   Notre joueur Richard a reçu la rondelle au visage (sans blessure, heureusement le masque a fait son travail!).\nCe fut un match agréable malgré l'heure tardive (20h00). Une longue pause de 7 heures entre le troisième et ce quatrième match a nécessité de refaire le réchauffement.\n\nEncore une victoire pour CAMO !"
       },
       "en": {
         "title": "Match #4 (Day 1): CAMO vs Raies of Rimouski",
-        "content": "Fourth update from the National Championship - Day 1!\n\n*   **Match Result:** CAMO wins 4-0 against Raies of Rimouski!\n*   **Match Notes:**\n    *   Intense play, some mistakes on our part.\n    *   A prolonged stop in play as our player Richard took a puck to the face.\n    *   Despite the late hour and the long pause, it was an enjoyable match.\n\nAnother win for CAMO!"
+        "content": "Fourth update from the National Championship - Day 1!\n\n*   **Match Result:** CAMO wins 4-0 against Raies of Rimouski!\n*   **Match Notes:**\n    *   Intense play and some mistakes on our part, with lots of stop play.\n    *   Our player Richard took a puck to the face (no injury, thankfully the mask did its job!).\nIt was an enjoyable match despite the late hour (8 PM). A long 7-hour pause between the third and this fourth match required a new warm-up.\n\nAnother win for CAMO!"
       }
     }
   ]

--- a/blog.json
+++ b/blog.json
@@ -52,6 +52,21 @@
         "title": "Match #3 (Day 1): CAMO's Resounding Victory Over GTA Raccoons!",
         "content": "Third update from the National Championship - Day 1!\n\n*   **Match Result:** CAMO secures a decisive 10-0 victory against the GTA Raccoons!\n    *   Excellent defense on our part, blocking numerous goal attempts from the opposition.\n    *   The GTA Raccoons are a young and promising team from the Greater Toronto Area. A fine new generation that will be very competitive in a few years.\n*   **Match Notes:**\n    *   A warning was issued to our captain, Philippe.\n    *   We were a bit slow and less reactive at the start of the match, but the team improved as it progressed!\n\nGo CAMO!"
       }
+    },
+    {
+      "id": "post-20250613210000",
+      "timestamp": "2025-06-13T21:00:00Z",
+      "image": null,
+      "sport_logo": "images/logos/uwh-logo.jpg",
+      "tags": ["uwh_nationals_2025"],
+      "fr": {
+        "title": "Match #4 (Jour 1) : CAMO vs Raies de Rimouski",
+        "content": "Quatrième mise à jour du Championnat National - Jour 1 !\n\n*   **Résultat du match :** Victoire de CAMO 4-0 contre les Raies de Rimouski !\n*   **Notes de match :**\n    *   Jeu intense et quelques erreurs de notre part.\n    *   Un arrêt de jeu prolongé car notre joueur Richard a reçu la rondelle au visage.\n    *   Malgré l'heure tardive et la longue pause, ce fut un match agréable.\n\nEncore une victoire pour CAMO !"
+      },
+      "en": {
+        "title": "Match #4 (Day 1): CAMO vs Raies of Rimouski",
+        "content": "Fourth update from the National Championship - Day 1!\n\n*   **Match Result:** CAMO wins 4-0 against Raies of Rimouski!\n*   **Match Notes:**\n    *   Intense play, some mistakes on our part.\n    *   A prolonged stop in play as our player Richard took a puck to the face.\n    *   Despite the late hour and the long pause, it was an enjoyable match.\n\nAnother win for CAMO!"
+      }
     }
   ]
 }


### PR DESCRIPTION
This commit adds a new blog post detailing the results and events of the fourth match you played at the 2025 Canadian Underwater Hockey Nationals.

The match was against Raies of Rimouski, with your team winning 4-0. The post includes details about the game's intensity, some mistakes, a puck incident involving Richard, and your team's enjoyment despite a late start.

The post has been added to `blog.json` with both French and English translations and will be dynamically rendered on `blog.html`.