### PR TITLE
Add historical posters to slideshow

### DIFF
--- a/docs/histoire_camo_hockey_subaquatique.en.md
+++ b/docs/histoire_camo_hockey_subaquatique.en.md
@@ -69,16 +69,21 @@ silver medals.
 
 ## Revival and Sustainable Development (2010-2011)
 The CAMO underwater hockey club experienced a revival in the 2010s. Recent years have seen the arrival of a new group of administrators pushing for sustainable development. In 2011, the club welcomed underwater rugby into its fold.
+## 2009 Poster
 ![2009 Poster](../images/affiches/2009-affiche.jpg)
 
 ## Organization of the Montreal Tournament (Since 2012)
 In 2012, succeeding the late JFK Aquatic Club, CAMO took over the organization of the Montreal tournament at the Claude-Robillard Sports Complex, annually attracting, since the late 90s, about fifteen teams from Quebec, Ontario, Western Canada, and the United States.
+## 2014 Poster
 ![2014 Poster](../images/affiches/2014-affiche.jpg)
+## 2015 "Try It" Poster
 ![2015 Try It Poster](../images/affiches/2015-essaye-le.jpg)
 
 ## The CAMO Club Today (Present)
 At the club, one can find players from the older generation as well as elite Canadian players who have marked the history of hockey in Quebec, Canada, and around the world. The club proudly welcomes players of all levels, from here and elsewhere.
+## 2018 "Surface" Poster
 ![2018 Surface Poster](../images/affiches/2018-surface.jpg)
+## 2023 Poster
 ![2023 Poster](../images/affiches/2023-affiche.jpg)
 
 ## Training and Level of Play (Present)

--- a/docs/histoire_camo_hockey_subaquatique.en.md
+++ b/docs/histoire_camo_hockey_subaquatique.en.md
@@ -69,12 +69,17 @@ silver medals.
 
 ## Revival and Sustainable Development (2010-2011)
 The CAMO underwater hockey club experienced a revival in the 2010s. Recent years have seen the arrival of a new group of administrators pushing for sustainable development. In 2011, the club welcomed underwater rugby into its fold.
+![2009 Poster](../images/affiches/2009-affiche.jpg)
 
 ## Organization of the Montreal Tournament (Since 2012)
 In 2012, succeeding the late JFK Aquatic Club, CAMO took over the organization of the Montreal tournament at the Claude-Robillard Sports Complex, annually attracting, since the late 90s, about fifteen teams from Quebec, Ontario, Western Canada, and the United States.
+![2014 Poster](../images/affiches/2014-affiche.jpg)
+![2015 Try It Poster](../images/affiches/2015-essaye-le.jpg)
 
 ## The CAMO Club Today (Present)
 At the club, one can find players from the older generation as well as elite Canadian players who have marked the history of hockey in Quebec, Canada, and around the world. The club proudly welcomes players of all levels, from here and elsewhere.
+![2018 Surface Poster](../images/affiches/2018-surface.jpg)
+![2023 Poster](../images/affiches/2023-affiche.jpg)
 
 ## Training and Level of Play (Present)
 As in the past, rookies and veterans train together to improve their game and gain experience. The level of play is intense, fast, and competitive.

--- a/docs/histoire_camo_hockey_subaquatique.fr.md
+++ b/docs/histoire_camo_hockey_subaquatique.fr.md
@@ -65,12 +65,17 @@ Il faut attendre près de 10 ans avant de voir arriver une nouvelle génération
 
 ## Renouveau et développement durable (2010-2011)
 Le club CAMO hockey sous-marin vit un renouveau dans les années 2010. Les dernières années ont vu arriver un nouveau groupe d'administrateurs qui poussent pour un développement durable. En 2011, le club accueille le rugby sous-marin dans son giron.
+![Affiche 2009](../images/affiches/2009-affiche.jpg)
 
 ## Organisation du tournoi de Montréal (Depuis 2012)
 En 2012, succédant au feu Club Aquatique de JFK, CAMO prend sous sa gouverne l’organisation du tournoi de Montréal au Complexe sportif Claude-Robillard attirant annuellement, depuis la fin des années 90, une quinzaine d’équipes du Québec, de l’Ontario, de l’ouest du pays et des États-Unis.
+![Affiche 2014](../images/affiches/2014-affiche.jpg)
+![Affiche 2015](../images/affiches/2015-essaye-le.jpg)
 
 ## Le club CAMO aujourd'hui (Présent)
 Au club, on y rencontre autant des joueurs de l’ancienne génération que des joueurs de l’élite canadienne qui ont marqué l’histoire du hockey au Québec, au Canada et dans le monde. Le club accueille avec fierté les joueurs de tous niveaux d’ici et d’ailleurs.
+![Surface 2018](../images/affiches/2018-surface.jpg)
+![Affiche 2023](../images/affiches/2023-affiche.jpg)
 
 ## Entraînement et niveau de jeu (Présent)
 Comme par le passé, recrues et anciens s’y entraînent pour améliorer leur niveau de jeu et gagner en expérience. Le niveau de jeu est intense, rapide et compétitif.

--- a/docs/histoire_camo_hockey_subaquatique.fr.md
+++ b/docs/histoire_camo_hockey_subaquatique.fr.md
@@ -65,16 +65,21 @@ Il faut attendre près de 10 ans avant de voir arriver une nouvelle génération
 
 ## Renouveau et développement durable (2010-2011)
 Le club CAMO hockey sous-marin vit un renouveau dans les années 2010. Les dernières années ont vu arriver un nouveau groupe d'administrateurs qui poussent pour un développement durable. En 2011, le club accueille le rugby sous-marin dans son giron.
+## Affiche 2009
 ![Affiche 2009](../images/affiches/2009-affiche.jpg)
 
 ## Organisation du tournoi de Montréal (Depuis 2012)
 En 2012, succédant au feu Club Aquatique de JFK, CAMO prend sous sa gouverne l’organisation du tournoi de Montréal au Complexe sportif Claude-Robillard attirant annuellement, depuis la fin des années 90, une quinzaine d’équipes du Québec, de l’Ontario, de l’ouest du pays et des États-Unis.
+## Affiche 2014
 ![Affiche 2014](../images/affiches/2014-affiche.jpg)
+## Affiche 2015
 ![Affiche 2015](../images/affiches/2015-essaye-le.jpg)
 
 ## Le club CAMO aujourd'hui (Présent)
 Au club, on y rencontre autant des joueurs de l’ancienne génération que des joueurs de l’élite canadienne qui ont marqué l’histoire du hockey au Québec, au Canada et dans le monde. Le club accueille avec fierté les joueurs de tous niveaux d’ici et d’ailleurs.
+## Affiche Surface 2018
 ![Surface 2018](../images/affiches/2018-surface.jpg)
+## Affiche 2023
 ![Affiche 2023](../images/affiches/2023-affiche.jpg)
 
 ## Entraînement et niveau de jeu (Présent)


### PR DESCRIPTION
This commit adds five historical posters to the history slideshow (`history.html`). The images were inserted into the corresponding year sections in both the French and English versions of the slideshow's Markdown source files:
- `docs/histoire_camo_hockey_subaquatique.fr.md`
- `docs/histoire_camo_hockey_subaquatique.en.md`

The new images are:
- images/affiches/2009-affiche.jpg
- images/affiches/2014-affiche.jpg
- images/affiches/2015-essaye-le.jpg
- images/affiches/2018-surface.jpg
- images/affiches/2023-affiche.jpg

Image paths and alt text have been verified for correctness.