### PR TITLE
Fix: Correct blog post timestamp and display timezone

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -261,7 +261,7 @@
                 const timestampElFr = document.createElement('p');
                 timestampElFr.className = 'text-sm text-gray-500 mb-4 text-center';
                 try {
-                    timestampElFr.textContent = new Date(post.timestamp).toLocaleDateString('fr-CA', { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+                    timestampElFr.textContent = new Date(post.timestamp).toLocaleDateString('fr-CA', { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit', timeZoneName: 'short' });
                 } catch (e) { timestampElFr.textContent = post.timestamp; }
                 frDiv.appendChild(timestampElFr);
 
@@ -303,7 +303,7 @@
                 const timestampElEn = document.createElement('p');
                 timestampElEn.className = 'text-sm text-gray-500 mb-4 text-center';
                 try {
-                    timestampElEn.textContent = new Date(post.timestamp).toLocaleDateString('en-CA', { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+                    timestampElEn.textContent = new Date(post.timestamp).toLocaleDateString('en-CA', { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit', timeZoneName: 'short' });
                 } catch (e) { timestampElEn.textContent = post.timestamp; }
                 enDiv.appendChild(timestampElEn);
 

--- a/blog.json
+++ b/blog.json
@@ -64,7 +64,7 @@
     },
     {
       "id": "post-20250613210000",
-      "timestamp": "2025-06-13T21:00:00Z",
+      "timestamp": "2025-06-14T01:00:00Z",
       "image": null,
       "sport_logo": "images/logos/uwh-logo.jpg",
       "tags": ["uwh_nationals_2025"],


### PR DESCRIPTION
This commit addresses an issue where a blog post for Match #4 showed an incorrect publication time and did not display the timezone.

- I updated the timestamp for Match #4 (id: "post-20250613210000") in `blog.json` to `2025-06-14T01:00:00Z`. This corresponds to June 13, 2025, 9:00 PM EDT, which is 1 hour after the match's start time (8:00 PM EDT), making the publication time logical.
- I modified the JavaScript in `blog.html` to include the `timeZoneName: 'short'` option in the `toLocaleDateString` calls for both French and English. This will ensure that the timezone abbreviation (e.g., EDT, EST) is displayed alongside the time, providing clarity to you.