### PR TITLE
Add blog post for CAMO vs Quebec match (June 14)

### DIFF
--- a/blog.json
+++ b/blog.json
@@ -86,11 +86,11 @@
       "tags": ["uwh_nationals_2025"],
       "fr": {
         "title": "Jour 2 Nationaux: Victoire de CAMO 1-0 contre Québec!",
-        "content": "blog update: jour 2 (14 juin), premier match CAMO (Montréal) contre Québec ce matin à 8h30. Résultat: 1-0! Québec est une équipe très forte, donc nous sommes très heureux du résultat. Un point compté dans la première période et un point est tout ce que nous avions besoin pour gagner suivi d'une défense archarnée. Cette victoire nous garanti déjà une 4ième position!"
+        "content": "Mise à jour du blogue : Jour 2 (14 juin).\n\nPremier match pour CAMO (Montréal) contre Québec ce matin à 8h30.\n\n*   **Résultat :** Victoire de CAMO 1-0 !\n*   **Commentaire :** Québec est une équipe très forte, donc nous sommes très heureux du résultat. Un point compté dans la première période était tout ce dont nous avions besoin pour gagner, suivi d'une défense acharnée.\n*   **Classement :** Cette victoire nous garantit déjà une 4ième position !\n"
       },
       "en": {
         "title": "Nationals Day 2: CAMO Wins 1-0 Against Quebec!",
-        "content": "Blog update: Day 2 (June 14), first match CAMO (Montreal) vs Quebec this morning at 8:30 AM. Result: 1-0! Quebec is a very strong team, so we are very happy with the result. One goal scored in the first period was all we needed to win, followed by a fierce defense. This victory already guarantees us at least 4th position!"
+        "content": "Blog update: Day 2 (June 14).\n\nFirst match for CAMO (Montreal) against Quebec this morning at 8:30 AM.\n\n*   **Result:** CAMO wins 1-0!\n*   **Comments:** Quebec is a very strong team, so we are very happy with the result. One goal scored in the first period was all we needed to win, followed by a fierce defense.\n*   **Standings:** This victory already guarantees us at least 4th position!\n"
       }
     }
   ]

--- a/blog.json
+++ b/blog.json
@@ -76,6 +76,22 @@
         "title": "Match #4 (Day 1): CAMO vs Raies of Rimouski",
         "content": "Fourth update from the National Championship - Day 1!\n\n*   **Match Result:** CAMO wins 4-0 against Raies of Rimouski!\n*   **Match Notes:**\n    *   Intense play and some mistakes on our part, with lots of stop play.\n    *   Our player Richard took a puck to the face (no injury, thankfully the mask did its job!).\nIt was an enjoyable match despite the late hour (8 PM). A long 7-hour pause between the third and this fourth match required a new warm-up.\n\nAnother win for CAMO!"
       }
+    },
+    {
+      "id": "post-20250614083000",
+      "timestamp": "2025-06-14T12:30:00Z",
+      "image": null,
+      "images": [],
+      "sport_logo": "images/logos/uwh-logo.jpg",
+      "tags": ["uwh_nationals_2025"],
+      "fr": {
+        "title": "Jour 2 Nationaux: Victoire de CAMO 1-0 contre Québec!",
+        "content": "blog update: jour 2 (14 juin), premier match CAMO (Montréal) contre Québec ce matin à 8h30. Résultat: 1-0! Québec est une équipe très forte, donc nous sommes très heureux du résultat. Un point compté dans la première période et un point est tout ce que nous avions besoin pour gagner suivi d'une défense archarnée. Cette victoire nous garanti déjà une 4ième position!"
+      },
+      "en": {
+        "title": "Nationals Day 2: CAMO Wins 1-0 Against Quebec!",
+        "content": "Blog update: Day 2 (June 14), first match CAMO (Montreal) vs Quebec this morning at 8:30 AM. Result: 1-0! Quebec is a very strong team, so we are very happy with the result. One goal scored in the first period was all we needed to win, followed by a fierce defense. This victory already guarantees us at least 4th position!"
+      }
     }
   ]
 }


### PR DESCRIPTION
This commit adds a new blog post to `blog.json` detailing the result of the CAMO vs Quebec match on June 14th.

Details:
- Date: June 14, 2025, 8:30 AM (local time)
- Match: CAMO (Montreal) vs Quebec
- Result: CAMO wins 1-0
- Significance: Guarantees CAMO at least 4th position.

The post includes both French (original text) and English (translated) versions. It is tagged appropriately for the UWH Nationals 2025.