### PR TITLE
Fix: Ensure newlines in blog posts render correctly

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -211,6 +211,7 @@
   html = html.replace(/\[(.*?)\]\((.*?)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 underline">$1</a>'); // Links
 
   // Convert remaining newlines to <br>.
+  html = html.replace(/\\n/g, '<br>'); // Handle escaped newlines first
   html = html.replace(/\n/g, '<br>');
 
   // Remove <br> tags that might have been inserted around list tags or list items.


### PR DESCRIPTION
The `blog.json` data source contains newline characters encoded as the literal string "\n". The `basicMarkdownToHtml` function in `blog.html` was previously only converting actual newline characters to <br> tags.

This change updates the `basicMarkdownToHtml` function to first replace occurrences of the literal string "\n" with <br> tags. It then proceeds to replace any actual newline characters with <br> tags. This ensures that newlines from the current JSON structure are rendered correctly and also maintains compatibility should the JSON data start using standard
 newline characters in the future.