### PR TITLE
Fix: Add Tailwind CSS Typography plugin to blog.html

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -6,6 +6,7 @@
     <title>Blog - Club CAMO</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="assets/fontawesome/css/font-awesome.min.css">
+    <link href="https://cdn.tailwindcss.com/npm/@tailwindcss/typography@0.5.10/dist/typography.min.css" rel="stylesheet">
     <link rel="preload" as="image" href="images/camo-subaquatique.png">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-9V8Q4XJXLD"></script>


### PR DESCRIPTION
The Markdown content in blog posts was rendering without proper HTML styling because the Tailwind CSS Typography plugin was missing. This commit adds the CDN link for the plugin to `blog.html`.

The `marked.js` library correctly converted Markdown to HTML, and the `.prose` class was applied to the content containers. However, without the Typography plugin's CSS, the `.prose` class had no effect on styling elements like headings, lists, blockquotes, etc.

This change ensures that blog posts are displayed with the intended formatting provided by the Tailwind Typography plugin.