### PR TITLE
Add 'Summer 2025' clarification to practice schedule notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
             </div>
         </section>
 
-        <section class="bg-yellow-400 text-gray-900 py-6 text-center" data-aos="fade-in">
+        <section class="bg-sky-500 text-gray-900 py-6 text-center" data-aos="fade-in">
             <div class="container mx-auto">
                 <img src="competitions/uwh-nationals-2025/UWH-Nationals-2025-Black.png" alt="Logo Championnats Canadiens HSA 2025" class="mx-auto mb-4 h-24">
                 <p class="text-xl md:text-2xl font-semibold">
@@ -323,7 +323,7 @@
             </div>
         </section>
 
-        <section class="bg-yellow-400 text-gray-900 py-6 text-center" data-aos="fade-in">
+        <section class="bg-sky-500 text-gray-900 py-6 text-center" data-aos="fade-in">
             <div class="container mx-auto">
                 <img src="competitions/uwh-nationals-2025/UWH-Nationals-2025-Black.png" alt="UWH Nationals 2025 Logo" class="mx-auto mb-4 h-24">
                 <p class="text-xl md:text-2xl font-semibold">

--- a/index.html
+++ b/index.html
@@ -109,6 +109,18 @@
             </div>
         </header>
 
+        <section class="bg-orange-500 text-white py-6 text-center" data-aos="fade-in">
+            <div class="container mx-auto px-4">
+                <h2 class="text-2xl md:text-3xl font-bold mb-4">Horaire Spécial d'Été 2025</h2>
+                <p class="text-lg md:text-xl mb-2">
+                    <strong>Hockey Subaquatique:</strong> Les pratiques du Vendredi sont annulées à partir du 4 Juillet 2025. Retour des pratiques du Vendredi le 5 Septembre 2025. Les pratiques du Mardi sont maintenues.
+                </p>
+                <p class="text-lg md:text-xl">
+                    <strong>Rugby Subaquatique:</strong> Les pratiques du Samedi sont annulées à partir du 5 Juillet 2025. Retour des pratiques du Samedi le 6 Septembre 2025. Les pratiques du Mercredi sont maintenues.
+                </p>
+            </div>
+        </section>
+
         <section class="bg-yellow-400 text-gray-900 py-6 text-center" data-aos="fade-in">
             <div class="container mx-auto">
                 <img src="competitions/uwh-nationals-2025/UWH-Nationals-2025-Black.png" alt="Logo Championnats Canadiens HSA 2025" class="mx-auto mb-4 h-24">
@@ -298,6 +310,18 @@
                 <a href="history.html" class="text-xl hover:underline font-semibold ml-4">Our History</a>
             </div>
         </header>
+
+        <section class="bg-orange-500 text-white py-6 text-center" data-aos="fade-in">
+            <div class="container mx-auto px-4">
+                <h2 class="text-2xl md:text-3xl font-bold mb-4">Special Summer 2025 Schedule</h2>
+                <p class="text-lg md:text-xl mb-2">
+                    <strong>Underwater Hockey:</strong> Friday practices are cancelled starting July 4, 2025. Regular Friday practices will resume on September 5, 2025. Tuesday practices are maintained.
+                </p>
+                <p class="text-lg md:text-xl">
+                    <strong>Underwater Rugby:</strong> Saturday practices are cancelled starting July 5, 2025. Regular Saturday practices will resume on September 6, 2025. Wednesday practices are maintained.
+                </p>
+            </div>
+        </section>
 
         <section class="bg-yellow-400 text-gray-900 py-6 text-center" data-aos="fade-in">
             <div class="container mx-auto">

--- a/index.html
+++ b/index.html
@@ -139,6 +139,7 @@
                         Ce sport développe l'apnée, la force physique, l'agilité sous l'eau et la coordination d'équipe. Il est parfait pour ceux qui aiment les défis aquatiques et la collaboration.
                     </p>
                     <p class="text-lg font-semibold text-gray-900 mt-4">Pratiques régulières : <span class="font-normal">Mardi et Vendredi soirs</span></p>
+                    <p class="text-sm text-gray-700 mt-2"><strong>Horaire spécial d'été 2025:</strong> Les pratiques du Vendredi sont annulées à partir du 4 Juillet 2025. Retour des pratiques du Vendredi le 5 Septembre 2025.</p>
                     <a href="#entrainement-hockey" class="mt-6 inline-block bg-blue-700 text-white px-8 py-3 rounded-full font-semibold hover:bg-blue-800 transition duration-300 shadow-lg">Voir l'entraînement d'initiation</a>
                 </div>
 
@@ -154,6 +155,7 @@
                         Ce sport développe l'apnée, la puissance, la tactique spatiale et la capacité à travailler en équipe dans un environnement unique. Il est idéal pour les athlètes cherchant un sport aquatique intense et stratégique.
                     </p>
                     <p class="text-lg font-semibold text-gray-900 mt-4">Pratiques régulières : <span class="font-normal">Mercredi et Samedi soirs</span></p>
+                    <p class="text-sm text-gray-700 mt-2"><strong>Horaire spécial d'été 2025:</strong> Les pratiques du Samedi sont annulées à partir du 5 Juillet 2025. Retour des pratiques du Samedi le 6 Septembre 2025.</p>
                     <a href="#entrainement-rugby" class="mt-6 inline-block bg-green-700 text-white px-8 py-3 rounded-full font-semibold hover:bg-green-800 transition duration-300 shadow-lg">Voir l'entraînement d'initiation</a>
                 </div>
             </div>
@@ -329,6 +331,7 @@
                         This sport develops breath-holding, physical strength, underwater agility, and team coordination. It's perfect for those who enjoy aquatic challenges and collaboration.
                     </p>
                     <p class="text-lg font-semibold text-gray-900 mt-4">Regular practices: <span class="font-normal">Tuesday and Friday evenings</span></p>
+                    <p class="text-sm text-gray-700 mt-2"><strong>Special Summer 2025 Schedule:</strong> Friday practices are cancelled starting July 4, 2025. Regular Friday practices will resume on September 5, 2025.</p>
                     <a href="#entrainement-hockey-en" class="mt-6 inline-block bg-blue-700 text-white px-8 py-3 rounded-full font-semibold hover:bg-blue-800 transition duration-300 shadow-lg">See introductory training</a>
                 </div>
 
@@ -345,6 +348,7 @@
                         This sport develops breath-holding, power, spatial tactics, and the ability to work as a team in a unique environment. It's ideal for athletes seeking an intense and strategic aquatic sport.
                     </p>
                     <p class="text-lg font-semibold text-gray-900 mt-4">Regular practices: <span class="font-normal">Wednesday and Saturday evenings</span></p>
+                    <p class="text-sm text-gray-700 mt-2"><strong>Special Summer 2025 Schedule:</strong> Saturday practices are cancelled starting July 5, 2025. Regular Saturday practices will resume on September 6, 2025.</p>
                      <a href="#entrainement-rugby-en" class="mt-6 inline-block bg-green-700 text-white px-8 py-3 rounded-full font-semibold hover:bg-green-800 transition duration-300 shadow-lg">See introductory training</a>
                 </div>
 


### PR DESCRIPTION
- Updated French and English notes for Hockey and Rugby to explicitly state that the modified schedule is for Summer 2025.
- Notes include specific cancellation and resumption dates for Friday (Hockey) and Saturday (Rugby) practices.