### PR TITLE
Fix: Update summer practice schedule for Hockey and Rugby

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,12 +111,18 @@
 
         <section class="bg-orange-500 text-white py-6 text-center" data-aos="fade-in">
             <div class="container mx-auto px-4">
-                <h2 class="text-2xl md:text-3xl font-bold mb-4">Horaire Spécial d'Été 2025</h2>
+                <h2 class="text-2xl md:text-3xl font-bold mb-4">☀️ HORAIRE DES PRATIQUES POUR LA SAISON ESTIVALE ☀️</h2>
                 <p class="text-lg md:text-xl mb-2">
-                    <strong>Hockey Subaquatique:</strong> Les pratiques du Vendredi sont annulées à partir du 4 Juillet 2025. Retour des pratiques du Vendredi le 5 Septembre 2025. Les pratiques du Mardi sont maintenues.
+                    Veuillez noter que la dernière semaine d'activité avec l'horaire habituel se termine le 4 juillet 2025.
+                </p>
+                <p class="text-lg md:text-xl mb-2">
+                    <strong>Hockey Subaquatique:</strong> Les pratiques du vendredi seront annulées à partir du 11 juillet. Les pratiques débutants et pratiques régulières du mardi seront maintenues aux heures habituelles. Retour des pratiques du vendredi avec l'horaire habituel le 5 septembre.
                 </p>
                 <p class="text-lg md:text-xl">
-                    <strong>Rugby Subaquatique:</strong> Les pratiques du Samedi sont annulées à partir du 5 Juillet 2025. Retour des pratiques du Samedi le 6 Septembre 2025. Les pratiques du Mercredi sont maintenues.
+                    <strong>Rugby Subaquatique:</strong> Les pratiques du Samedi sont annulées à partir du 12 Juillet 2025. Retour des pratiques du Samedi le 6 Septembre 2025. Les pratiques du Mercredi sont maintenues.
+                </p>
+                <p class="text-lg md:text-xl mt-2">
+                    Bon été! 🤿
                 </p>
             </div>
         </section>
@@ -313,12 +319,18 @@
 
         <section class="bg-orange-500 text-white py-6 text-center" data-aos="fade-in">
             <div class="container mx-auto px-4">
-                <h2 class="text-2xl md:text-3xl font-bold mb-4">Special Summer 2025 Schedule</h2>
+                <h2 class="text-2xl md:text-3xl font-bold mb-4">☀️ SUMMER PRACTICE SCHEDULE ☀️</h2>
                 <p class="text-lg md:text-xl mb-2">
-                    <strong>Underwater Hockey:</strong> Friday practices are cancelled starting July 4, 2025. Regular Friday practices will resume on September 5, 2025. Tuesday practices are maintained.
+                    Please note that the last week of activities with the usual schedule ends on July 4, 2025.
+                </p>
+                <p class="text-lg md:text-xl mb-2">
+                    <strong>Underwater Hockey:</strong> Friday practices will be cancelled starting July 11, 2025. Beginner and regular Tuesday practices will be maintained at the usual times. Friday practices will return to the regular schedule on September 5, 2025.
                 </p>
                 <p class="text-lg md:text-xl">
-                    <strong>Underwater Rugby:</strong> Saturday practices are cancelled starting July 5, 2025. Regular Saturday practices will resume on September 6, 2025. Wednesday practices are maintained.
+                    <strong>Underwater Rugby:</strong> Saturday practices are cancelled starting July 12, 2025. Regular Saturday practices will resume on September 6, 2025. Wednesday practices are maintained.
+                </p>
+                <p class="text-lg md:text-xl mt-2">
+                    Have a great summer! 🤿
                 </p>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -116,10 +116,10 @@
                     Veuillez noter que la dernière semaine d'activité avec l'horaire habituel se termine le 4 juillet 2025.
                 </p>
                 <p class="text-lg md:text-xl mb-2">
-                    <strong>Hockey Subaquatique:</strong> Les pratiques du vendredi seront annulées à partir du 11 juillet. Les pratiques débutants et pratiques régulières du mardi seront maintenues aux heures habituelles. Retour des pratiques du vendredi avec l'horaire habituel le 5 septembre.
+                    <strong>Hockey Subaquatique:</strong> Les pratiques du vendredi seront annulées à partir du 11 juillet 2025. Les pratiques débutants et pratiques régulières du mardi seront maintenues aux heures habituelles. Retour des pratiques du vendredi avec l'horaire habituel le 5 septembre 2025.
                 </p>
                 <p class="text-lg md:text-xl">
-                    <strong>Rugby Subaquatique:</strong> Les pratiques du Samedi sont annulées à partir du 12 Juillet 2025. Retour des pratiques du Samedi le 6 Septembre 2025. Les pratiques du Mercredi sont maintenues.
+                    <strong>Rugby Subaquatique:</strong> Les pratiques du samedi sont annulées à partir du 12 juillet 2025. Retour des pratiques du samedi le 6 septembre 2025. Les pratiques du mercredi sont maintenues.
                 </p>
                 <p class="text-lg md:text-xl mt-2">
                     Bon été! 🤿
@@ -157,7 +157,7 @@
                         Ce sport développe l'apnée, la force physique, l'agilité sous l'eau et la coordination d'équipe. Il est parfait pour ceux qui aiment les défis aquatiques et la collaboration.
                     </p>
                     <p class="text-lg font-semibold text-gray-900 mt-4">Pratiques régulières : <span class="font-normal">Mardi et Vendredi soirs</span></p>
-                    <p class="text-sm text-gray-700 mt-2"><strong>Horaire spécial d'été 2025:</strong> Les pratiques du Vendredi sont annulées à partir du 4 Juillet 2025. Retour des pratiques du Vendredi le 5 Septembre 2025.</p>
+                    <p class="text-sm text-gray-700 mt-2"><strong>Horaire spécial d'été 2025:</strong> Les pratiques du vendredi sont annulées à partir du 11 juillet 2025. Retour des pratiques du vendredi le 5 septembre 2025.</p>
                     <a href="#entrainement-hockey" class="mt-6 inline-block bg-blue-700 text-white px-8 py-3 rounded-full font-semibold hover:bg-blue-800 transition duration-300 shadow-lg">Voir l'entraînement d'initiation</a>
                 </div>
 
@@ -173,7 +173,7 @@
                         Ce sport développe l'apnée, la puissance, la tactique spatiale et la capacité à travailler en équipe dans un environnement unique. Il est idéal pour les athlètes cherchant un sport aquatique intense et stratégique.
                     </p>
                     <p class="text-lg font-semibold text-gray-900 mt-4">Pratiques régulières : <span class="font-normal">Mercredi et Samedi soirs</span></p>
-                    <p class="text-sm text-gray-700 mt-2"><strong>Horaire spécial d'été 2025:</strong> Les pratiques du Samedi sont annulées à partir du 5 Juillet 2025. Retour des pratiques du Samedi le 6 Septembre 2025.</p>
+                    <p class="text-sm text-gray-700 mt-2"><strong>Horaire spécial d'été 2025:</strong> Les pratiques du samedi sont annulées à partir du 12 juillet 2025. Retour des pratiques du samedi le 6 septembre 2025.</p>
                     <a href="#entrainement-rugby" class="mt-6 inline-block bg-green-700 text-white px-8 py-3 rounded-full font-semibold hover:bg-green-800 transition duration-300 shadow-lg">Voir l'entraînement d'initiation</a>
                 </div>
             </div>
@@ -367,7 +367,7 @@
                         This sport develops breath-holding, physical strength, underwater agility, and team coordination. It's perfect for those who enjoy aquatic challenges and collaboration.
                     </p>
                     <p class="text-lg font-semibold text-gray-900 mt-4">Regular practices: <span class="font-normal">Tuesday and Friday evenings</span></p>
-                    <p class="text-sm text-gray-700 mt-2"><strong>Special Summer 2025 Schedule:</strong> Friday practices are cancelled starting July 4, 2025. Regular Friday practices will resume on September 5, 2025.</p>
+                    <p class="text-sm text-gray-700 mt-2"><strong>Special Summer 2025 Schedule:</strong> Friday practices are cancelled starting July 11, 2025. Regular Friday practices will resume on September 5, 2025.</p>
                     <a href="#entrainement-hockey-en" class="mt-6 inline-block bg-blue-700 text-white px-8 py-3 rounded-full font-semibold hover:bg-blue-800 transition duration-300 shadow-lg">See introductory training</a>
                 </div>
 
@@ -384,7 +384,7 @@
                         This sport develops breath-holding, power, spatial tactics, and the ability to work as a team in a unique environment. It's ideal for athletes seeking an intense and strategic aquatic sport.
                     </p>
                     <p class="text-lg font-semibold text-gray-900 mt-4">Regular practices: <span class="font-normal">Wednesday and Saturday evenings</span></p>
-                    <p class="text-sm text-gray-700 mt-2"><strong>Special Summer 2025 Schedule:</strong> Saturday practices are cancelled starting July 5, 2025. Regular Saturday practices will resume on September 6, 2025.</p>
+                    <p class="text-sm text-gray-700 mt-2"><strong>Special Summer 2025 Schedule:</strong> Saturday practices are cancelled starting July 12, 2025. Regular Saturday practices will resume on September 6, 2025.</p>
                      <a href="#entrainement-rugby-en" class="mt-6 inline-block bg-green-700 text-white px-8 py-3 rounded-full font-semibold hover:bg-green-800 transition duration-300 shadow-lg">See introductory training</a>
                 </div>
 


### PR DESCRIPTION
Updated the French and English summer schedules based on user request.

For Underwater Hockey (French and English):
- Friday practices cancelled starting July 11th (previously July 4th).
- Added note: Last week of normal schedule ends July 4th.
- Added note: Tuesday beginner and regular practices maintained.

For Underwater Rugby (French and English):
- Saturday practices cancelled starting July 12th (previously July 5th).