### PR TITLE
Remove obsolete information

### DIFF
--- a/.github/workflows/preview-pages.yml
+++ b/.github/workflows/preview-pages.yml
@@ -35,7 +35,7 @@ jobs:
         run: htmlhint index.html
 
       - name: Set up GitHub Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
 
       - name: Create version.json
         run: echo "{\"commit\":\"${{ github.sha }}\", \"branch\":\"${{ github.head_ref }}\"}" > version.json
@@ -44,49 +44,16 @@ jobs:
         id: pr_number
         run: echo "PR_NUM=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
 
-      - name: Create temporary directory for deployment
-        run: mkdir temp_deploy
-
-      - name: Get latest successful main site workflow run ID
-        id: get_run_id
-        uses: actions/github-script@v7
+      - name: Checkout main branch for base site
+        uses: actions/checkout@v4
         with:
-          script: |
-            const workflowRuns = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'static.yml',
-              branch: 'main',
-              status: 'success',
-              per_page: 1
-            });
-            if (workflowRuns.data.total_count === 0) {
-              core.setFailed('No successful workflow runs found for static.yml on main branch.');
-              return;
-            }
-            const run_id = workflowRuns.data.workflow_runs[0].id;
-            core.setOutput('run_id', run_id);
-            console.log(`Found run_id: ${run_id}`);
-            return run_id;
-
-      - name: Download latest main site artifact
-        uses: actions/download-artifact@v4
-        id: download_main_artifact
-        with:
-          name: github-pages
-          path: temp_deploy # Download directly into the temp directory
-          repository: ${{ github.repository }}
-          run-id: ${{steps.get_run_id.outputs.run_id}}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract main site artifact
-        run: find ${{ steps.download_main_artifact.outputs.download-path }} -maxdepth 1 -name '*.tar' -exec tar -xf {} -C temp_deploy \; -exec rm {} \;
+          ref: main
+          path: temp_deploy
 
       - name: Verify index.html exists at root
         run: |
           if [ ! -f temp_deploy/index.html ]; then
-            echo "ERROR: temp_deploy/index.html not found after unzip!"
-            echo "This likely means the downloaded archive has an unexpected internal directory structure."
+            echo "ERROR: temp_deploy/index.html not found!"
             echo "Listing contents of temp_deploy for debugging:"
             ls -R temp_deploy
             exit 1

--- a/blog.json
+++ b/blog.json
@@ -19,7 +19,8 @@
       "en": {
         "title": "CAMO wins gold at the 2025 Seaway Valley Fall Classic",
         "content_md": "blog/posts/seaway-valley-fall-classic-2025.en.md"
-      }
+      },
+      "archived": true
     },
     {
       "id": "montreal-summer-tournament-2025",
@@ -32,7 +33,8 @@
       "en": {
         "title": "Montreal Summer Tournament Semi-Final and Final",
         "content_md": "blog/posts/montreal-summer-tournament-2025.en.md"
-      }
+      },
+      "archived": true
     },
     {
       "id": "tournoi-estival-2025",
@@ -45,7 +47,8 @@
       "en": {
         "title": "Montreal Summer Tournament - It's today!",
         "content": "Fans of unusual sports and thrills, get your swimsuits ready! The long-awaited Montreal Underwater Hockey Summer Tournament is happening **today**. The competition is fierce and the show, unforgettable.\n\n### A day of intense competition\n\nStarting at **12:30 PM**, teams are competing in the depths of the magnificent **Parc Jean-Drapeau swimming pool**. Whether you're a seasoned player or simply curious to discover this fascinating sport, the tournament promises moments of pure adrenaline until the grand final at **6:45 PM**.\n\nUnderwater hockey is a complete sport that combines swimming, freediving, and team strategy. It's a unique opportunity to see athletes push their limits in an extraordinary environment.\n\n### Ranking Matches Results\n\nA tough competition for CAMO. Here are the results of the ranking matches:\n\n- **CAMO 4-3 Gatineau/Ottawa**\n- **CAMO 3-4 Sherbrooke**\n- **CAMO 0-10 Cornwall**\n\nThe semi-finals and the final are yet to come!\n\n### Don't miss any of the action!\n\nTo get all the details about the games, participating teams, and live rankings, check out the official tournament schedule:\n\n[Schedule Link](https://docs.google.com/spreadsheets/d/1xhwARu0RJzODM13oIlTYRmy52nGoWmCt/edit?usp=drivesdk&ouid=112734382006949623750&rtpof=true&sd=true)\n\nAnd to stay connected, follow the latest news, and share your excitement, join the event on Facebook:\n\n[Facebook Page Link](https://facebook.com/events/s/tournoi-estival-de-montreal-20/1056767486301457/)\n\n### Follow the competition!\n\nThe action is happening behind closed doors, but you can follow the live results and support your favorite teams through our social media channels and the schedule link."
-      }
+      },
+      "archived": true
     },
     {
       "id": "post-202506152200-nationals-2025-thank-you",
@@ -66,7 +69,8 @@
         "competitions/uwh-nationals-2025/gala/deck.jpg",
         "competitions/uwh-nationals-2025/gala/volontaires.jpg",
         "competitions/uwh-nationals-2025/gala/arbitres.jpg"
-      ]
+      ],
+      "archived": true
     },
     {
       "id": "post-202506151800-jour3-match9-gta-camo",
@@ -87,7 +91,8 @@
         "competitions/uwh-nationals-2025/match9/10-prematch.jpg",
         "competitions/uwh-nationals-2025/match9/20-postmatch.jpg",
         "competitions/uwh-nationals-2025/match9/30-medaille.jpg"
-      ]
+      ],
+      "archived": true
     },
     {
       "id": "post-20240728100000",
@@ -104,7 +109,8 @@
       "en": {
         "title": "Canadian Underwater Hockey Nationals in Gatineau - Day 1!",
         "content": "Team CAMO (camosub.ca) is in full swing! An emotion-packed day.\\n\\n*   **Match Result:** Victory 6-1 against Vert Huard (Sherbrooke Club)!\\n    *   Score at the first half: 2-1.\\n    *   Our star player Joseph joined us in the second half after a slight delay due to car trouble.\\n*   **Full Schedule:** [Follow the action here](https://uwhportal.com/events/ca-2025-canadian-underwater-hockey-nationals?table-view=schedule)\\n\\nStay tuned for more updates!"
-      }
+      },
+      "archived": true
     },
     {
       "id": "post-20250613123000",
@@ -121,7 +127,8 @@
       "en": {
         "title": "Match #2 (Day 1): CAMO vs Deimos (EX) - A Tight Draw!",
         "content": "Second update from the National Championship!\\n\\n*   **Match Result:** CAMO draws 2-2 against Deimos (EX)!\\n    *   Deimos is an excellent American team, with players who are candidates for the U.S. National Team.\\n    *   They will not participate in the playoff rounds (as they are non-Canadian).\\n*   **Highlight:** A penalty shot against us was brilliantly defended by Joseph! Unfortunately, the goal was disallowed by the referees due to a defensive foul.\\n\\nWhat an intense game!"
-      }
+      },
+      "archived": true
     },
     {
       "id": "post-20250613143000",
@@ -147,7 +154,8 @@
       "en": {
         "title": "Match #3 (Day 1): CAMO's Resounding Victory Over GTA Raccoons!",
         "content": "Third update from the National Championship - Day 1!\\n\\n*   **Match Result:** CAMO secures a decisive 10-0 victory against the GTA Raccoons!\\n    *   Excellent defense on our part, blocking numerous goal attempts from the opposition.\\n    *   The GTA Raccoons are a young and promising team from the Greater Toronto Area. A fine new generation that will be very competitive in a few years.\\n*   **Match Notes:**\\n    *   A warning was issued to our captain, Philippe.\\n    *   We were a bit slow and less reactive at the start of the match, but the team improved as it progressed!\\n\\nGo CAMO!"
-      }
+      },
+      "archived": true
     },
     {
       "id": "post-20250613210000",
@@ -164,7 +172,8 @@
       "en": {
         "title": "Match #4 (Day 1): CAMO vs Raies of Rimouski",
         "content": "Fourth update from the National Championship - Day 1!\\n\\n*   **Match Result:** CAMO wins 4-0 against Raies of Rimouski!\\n*   **Match Notes:**\\n    *   Intense play and some mistakes on our part, with lots of stop play.\\n    *   Our player Richard took a puck to the face (no injury, thankfully the mask did its job!).\\nIt was an enjoyable match despite the late hour (8 PM). A long 7-hour pause between the third and this fourth match required a new warm-up.\\n\\nAnother win for CAMO!"
-      }
+      },
+      "archived": true
     },
     {
       "id": "post-20250614083000",
@@ -182,7 +191,8 @@
       "en": {
         "title": "Nationals Day 2 Match #6 (Game #25): CAMO Wins 1-0 Against Quebec! (08h30)",
         "content": "Blog update: Day 2 (June 14).\\n\\nFirst match for CAMO (Montreal) against Quebec this morning at 8:30 AM.\\n\\n*   **Result:** CAMO wins 1-0!\\n*   **Comments:** Quebec is a very strong team, so we are very happy with the result. One goal scored in the first period was all we needed to win, followed by a fierce defense.\\n*   **Standings:** This victory already guarantees us at least 4th position!\\n"
-      }
+      },
+      "archived": true
     },
     {
       "id": "post-20240731130519-jour2-match2-nova",
@@ -198,7 +208,8 @@
       "en": {
         "title": "Day 2 Match #5 (Game #31): CAMO vs Nova (Vancouver) - Victory! (11h30)",
         "content": "Team CAMO faced Nova (Vancouver) in their second match of Day 2. Result: CAMO wins 2-1! Notable points: Opponent's goal scored while CAMO was shorthanded with two players in the penalty box. Numerous penalties and disadvantages against us. Team play was not up to the team's usual standard, but the win is secured!"
-      }
+      },
+      "archived": true
     },
     {
       "id": "post-20240731180519-jour2-match6-quebec",
@@ -214,7 +225,8 @@
       "en": {
         "title": "Day 2 Match #7 (Game #103): CAMO vs Québec - Crucial Victory! (17h15)",
         "content": "CAMO secured a 3-2 victory against Québec in a very intense and extremely important match! This result was decisive for our access to the medals. The upcoming matches will decide which medal we get."
-      }
+      },
+      "archived": true
     },
     {
       "id": "post-202506151130-jour3-match8-cornwall",
@@ -235,7 +247,8 @@
         "competitions/uwh-nationals-2025/match8/05-briefing.jpg",
         "competitions/uwh-nationals-2025/match8/10-preparation.jpg",
         "competitions/uwh-nationals-2025/match8/20-depart.png"
-      ]
+      ],
+      "archived": true
     }
   ]
 }

--- a/events.json
+++ b/events.json
@@ -14,7 +14,7 @@
     },
     "fr": {
       "title": "Championnats Canadiens de Hockey Subaquatique 2025",
-      "description": "Première journée du championnat Canadien de hockey subaquatique à Gatineau.... Avec mon équipe Camo Hockey Sous Marin (camosub.ca). Une journée forte en émotions qui s'annonce. Lien vers l'horaire : https://uwhportal.com/events/ca-2025-canadian-underwater-hockey-nationals?table-view=schedule 6-1 contre Vert Huard (club de Sherbrooke). 2-1 en première période et ensuite notre deuxième joueur étoile Joseph est arrivé en deuxième période (en retard à cause de problèmes d'automobile! Le Club CAMO est ravi de supporter nos athlètes qui participeront aux Championnats Canadiens de Hockey Subaquatique 2025 à Gatineau! Venez encourager les meilleures équipes du pays.\n\nPour les mises à jour en direct du tournoi, consultez notre <a href='blog.html' class='text-yellow-400 hover:underline'>blog ici</a> !",
+      "description": "Premi\u00e8re journ\u00e9e du championnat Canadien de hockey subaquatique \u00e0 Gatineau.... Avec mon \u00e9quipe Camo Hockey Sous Marin (camosub.ca). Une journ\u00e9e forte en \u00e9motions qui s'annonce. Lien vers l'horaire : https://uwhportal.com/events/ca-2025-canadian-underwater-hockey-nationals?table-view=schedule 6-1 contre Vert Huard (club de Sherbrooke). 2-1 en premi\u00e8re p\u00e9riode et ensuite notre deuxi\u00e8me joueur \u00e9toile Joseph est arriv\u00e9 en deuxi\u00e8me p\u00e9riode (en retard \u00e0 cause de probl\u00e8mes d'automobile! Le Club CAMO est ravi de supporter nos athl\u00e8tes qui participeront aux Championnats Canadiens de Hockey Subaquatique 2025 \u00e0 Gatineau! Venez encourager les meilleures \u00e9quipes du pays.\n\nPour les mises \u00e0 jour en direct du tournoi, consultez notre <a href='blog.html' class='text-yellow-400 hover:underline'>blog ici</a> !",
       "details": null,
       "url": "https://uwhportal.com/events/ca-2025-canadian-underwater-hockey-nationals"
     },
@@ -33,34 +33,34 @@
     "endDate": null,
     "time": "19h30 - 20h30",
     "recurrence": {
-        "fr": "Tous les Mardis",
-        "en": "Every Tuesday"
+      "fr": "Tous les Mardis",
+      "en": "Every Tuesday"
     },
     "rrule": "FREQ=WEEKLY;BYDAY=TU",
     "firstEventStartDate": "2024-09-03",
     "location": {
       "name": "Piscine Joseph-Charbonneau",
       "address": "8200 rue Rousselot",
-      "city": "Montréal",
+      "city": "Montr\u00e9al",
       "province": "QC",
       "postalCode": "H2E 1Z6",
       "country": "Canada",
       "mapsLink": "https://www.google.com/maps/place/CAMO+Subaquatique+(Hockey+et+Rugby+subaquatique)/@45.5510127,-73.6255532,17z/data=!3m1!4b1!4m6!3m5!1s0x4cc91925c683704b:0x2eaef70b5889d969!8m2!3d45.5510127!4d-73.6230037!16s%2Fg%2F11gfcs33yx?entry=ttu"
     },
     "fr": {
-      "title": "Entraînement pour Débutants : Joignez-vous à Nous !",
-      "description": "Participez à nos entraînements pour débutants chaque mardi soir et découvrez le hockey subaquatique !",
+      "title": "Entra\u00eenement pour D\u00e9butants : Joignez-vous \u00e0 Nous !",
+      "description": "Participez \u00e0 nos entra\u00eenements pour d\u00e9butants chaque mardi soir et d\u00e9couvrez le hockey subaquatique !",
       "details": null,
-      "cost": "10 $ (gratuit pour la première session)",
+      "cost": "10 $ (gratuit pour la premi\u00e8re session)",
       "equipmentNeeded": "Maillot de bain",
       "programTitle": "Au programme :",
       "programDetails": [
         "Initiation au hockey subaquatique",
         "Techniques de nage avec palmes",
         "Maniement de la rondelle",
-        "Stratégies de jeu et parties amicales"
+        "Strat\u00e9gies de jeu et parties amicales"
       ],
-      "notes": "Ouvert à tous les niveaux. Savoir nager confortablement est un prérequis. Équipement de base (palmes, masque, tuba, crosse, palet) peut être prêté sur demande.",
+      "notes": "Ouvert \u00e0 tous les niveaux. Savoir nager confortablement est un pr\u00e9requis. \u00c9quipement de base (palmes, masque, tuba, crosse, palet) peut \u00eatre pr\u00eat\u00e9 sur demande.",
       "url": "mailto:camo_underwater@hotmail.com"
     },
     "en": {
@@ -88,15 +88,15 @@
     "time": "13h00 - 19h00",
     "location": {
       "name": "Parc Jean-Drapeau",
-      "address": "Île Sainte-Hélène",
-      "city": "Montréal",
+      "address": "\u00cele Sainte-H\u00e9l\u00e8ne",
+      "city": "Montr\u00e9al",
       "province": "QC",
       "postalCode": "H3C 1A9",
       "country": "Canada"
     },
     "fr": {
-      "title": "Tournoi estival de Montréal 2025",
-      "description": "Le club CAMO est fier de vous annoncer la quatrième édition de son tournoi estival. Celui-ci aura lieu au parc Jean-Drapeau le 12 juillet. Les équipes intéressées doivent noter que le nombre de places est limité, il est donc recommandé de réserver rapidement.",
+      "title": "Tournoi estival de Montr\u00e9al 2025",
+      "description": "Le club CAMO est fier de vous annoncer la quatri\u00e8me \u00e9dition de son tournoi estival. Celui-ci aura lieu au parc Jean-Drapeau le 12 juillet. Les \u00e9quipes int\u00e9ress\u00e9es doivent noter que le nombre de places est limit\u00e9, il est donc recommand\u00e9 de r\u00e9server rapidement.",
       "details": null,
       "url": "https://facebook.com/events/s/tournoi-estival-de-montreal-20/1056767486301457/"
     },
@@ -106,6 +106,7 @@
       "details": null,
       "url": "https://facebook.com/events/s/tournoi-estival-de-montreal-20/1056767486301457/"
     },
-    "image": null
+    "image": null,
+    "archived": true
   }
 ]

--- a/events_rss.xml
+++ b/events_rss.xml
@@ -6,7 +6,7 @@
     <description>Upcoming events</description>
     <docs>http://www.rssboard.org/rss-specification</docs>
     <generator>python-feedgen</generator>
-    <lastBuildDate>Sun, 21 Sep 2025 19:54:05 +0000</lastBuildDate>
+    <lastBuildDate>Tue, 11 Aug 2026 16:46:59 +0000</lastBuildDate>
     <item>
       <title>Tournoi estival de Montréal 2025</title>
       <link>https://camosub.ca/events/summer-tournament-2025</link>

--- a/events_rss.xml
+++ b/events_rss.xml
@@ -6,7 +6,7 @@
     <description>Upcoming events</description>
     <docs>http://www.rssboard.org/rss-specification</docs>
     <generator>python-feedgen</generator>
-    <lastBuildDate>Tue, 11 Aug 2026 16:46:59 +0000</lastBuildDate>
+    <lastBuildDate>Sun, 21 Sep 2025 19:54:05 +0000</lastBuildDate>
     <item>
       <title>Tournoi estival de Montréal 2025</title>
       <link>https://camosub.ca/events/summer-tournament-2025</link>

--- a/events_rss.xml
+++ b/events_rss.xml
@@ -6,7 +6,7 @@
     <description>Upcoming events</description>
     <docs>http://www.rssboard.org/rss-specification</docs>
     <generator>python-feedgen</generator>
-    <lastBuildDate>Sun, 21 Sep 2025 19:54:05 +0000</lastBuildDate>
+    <lastBuildDate>Tue, 11 Aug 2026 17:54:15 +0000</lastBuildDate>
     <item>
       <title>Tournoi estival de Montréal 2025</title>
       <link>https://camosub.ca/events/summer-tournament-2025</link>

--- a/index.html
+++ b/index.html
@@ -216,11 +216,8 @@
                 <div class="flex flex-col items-center space-y-4">
                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-envelope"></i> Courriel général :</span> <a href="mailto:info@camosub.ca" class="text-blue-400 hover:underline">info@camosub.ca</a></p>
                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-envelope"></i> Courriel hockey subaquatique :</span> <a href="mailto:camo_underwater@hotmail.com" class="text-blue-400 hover:underline">camo_underwater@hotmail.com</a></p>
-                    <p class="text-xl"><span class="font-semibold"><i class="fa fa-envelope"></i> Courriel rugby subaquatique :</span> <a href="mailto:uwr.camo@gmail.com" class="text-blue-400 hover:underline">uwr.camo@gmail.com</a></p>
-                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-facebook"></i> Facebook hockey subaquatique :</span> <a href="https://www.facebook.com/CAMOhockeysousmarin/" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">CAMOhockeysousmarin</a></p>
-                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-facebook"></i> Facebook rugby subaquatique :</span> <a href="https://www.facebook.com/uwr.camo/" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">uwr.camo</a></p>
-                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-instagram"></i> Instagram rugby subaquatique :</span> <a href="https://www.instagram.com/uwr.camo/" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">uwr.camo</a></p>
-                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-instagram"></i> Instagram hockey subaquatique :</span> <a href="https://www.instagram.com/camo.underwater/" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">camo.underwater</a></p>
+                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-facebook"></i> Facebook (hockey et rugby) :</span> <a href="https://www.facebook.com/CAMOhockeysousmarin/" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">CAMOhockeysousmarin</a></p>
+                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-instagram"></i> Instagram (hockey et rugby) :</span> <a href="https://www.instagram.com/camo.underwater/" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">camo.underwater</a></p>
                      <p class="text-xl mt-6"><span class="font-semibold">Lieu de pratique :</span></p>
                      <p class="text-lg">
                         Piscine Joseph-Charbonneau
@@ -464,11 +461,8 @@
                 <div class="flex flex-col items-center space-y-4">
                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-envelope"></i> General Email:</span> <a href="mailto:info@camosub.ca" class="text-blue-400 hover:underline">info@camosub.ca</a></p>
                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-envelope"></i> Underwater Hockey Email:</span> <a href="mailto:camo_underwater@hotmail.com" class="text-blue-400 hover:underline">camo_underwater@hotmail.com</a></p>
-                    <p class="text-xl"><span class="font-semibold"><i class="fa fa-envelope"></i> Underwater Rugby Email:</span> <a href="mailto:uwr.camo@gmail.com" class="text-blue-400 hover:underline">uwr.camo@gmail.com</a></p>
-                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-facebook"></i> Underwater Hockey Facebook:</span> <a href="https://www.facebook.com/CAMOhockeysousmarin/" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">CAMOhockeysousmarin</a></p>
-                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-facebook"></i> Underwater Rugby Facebook:</span> <a href="https://www.facebook.com/uwr.camo/" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">uwr.camo</a></p>
-                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-instagram"></i> Underwater Rugby Instagram:</span> <a href="https://www.instagram.com/uwr.camo/" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">uwr.camo</a></p>
-                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-instagram"></i> Underwater Hockey Instagram:</span> <a href="https://www.instagram.com/camo.underwater/" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">camo.underwater</a></p>
+                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-facebook"></i> Facebook (hockey & rugby):</span> <a href="https://www.facebook.com/CAMOhockeysousmarin/" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">CAMOhockeysousmarin</a></p>
+                     <p class="text-xl"><span class="font-semibold"><i class="fa fa-instagram"></i> Instagram (hockey & rugby):</span> <a href="https://www.instagram.com/camo.underwater/" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">camo.underwater</a></p>
                      <p class="text-xl mt-6"><span class="font-semibold">Practice Location:</span></p>
                      <p class="text-lg">
                         Piscine Joseph-Charbonneau


### PR DESCRIPTION
Archived the 2025 summer tournament in events.json and removed obsolete underwater rugby contact information from the index.html page, consolidating the links to cover both sports.

---
*PR created automatically by Jules for task [909102207206329457](https://jules.google.com/task/909102207206329457) started by @rngadam*